### PR TITLE
删除 海曼科技院-配方 组别，将下属物品修改为recipe_types

### DIFF
--- a/HaimanTech2-rsc/items.yml
+++ b/HaimanTech2-rsc/items.yml
@@ -4,11 +4,11 @@ HAIMANTECH_INFO:
   item:
     name: '&c&l海曼科技院说明书'
     lore:
-    - '&7本附属由海曼（haiman）编写而成'
-    - '&7感谢yitoudaidai和yh_mc曾经与我的合作'
-    - '&7感谢所有给予信任并安装海曼科技院的腐竹'
-    - '&7灵感来源于广大玩家'
-    - '&6海曼科技——始于2020年12月'
+      - '&7本附属由海曼（haiman）编写而成'
+      - '&7感谢yitoudaidai和yh_mc曾经与我的合作'
+      - '&7感谢所有给予信任并安装海曼科技院的腐竹'
+      - '&7灵感来源于广大玩家'
+      - '&6海曼科技——始于2020年12月'
     material_type: mc
     material: PAPER
     amount: 1
@@ -20,9 +20,9 @@ VERSION_INFO:
   item:
     name: '&c&l版本号'
     lore:
-    - '&f当前海曼科技院版本：'
-    - '&bRelease-1.5.1'
-    - '&7您在提issues的时候需要展示这个'
+      - '&f当前海曼科技院版本：'
+      - '&bRelease-1.5.1'
+      - '&7您在提issues的时候需要展示这个'
     material_type: mc
     material: PAPER
     amount: 1
@@ -39,1479 +39,270 @@ ZHANWEIFU:
     amount: 1
   placeable: false
   recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: mc
-      material: LIGHT_GRAY_STAINED_GLASS_PANE
-      amount: 1
-    2:
-      material_type: mc
-      material: LIGHT_GRAY_STAINED_GLASS_PANE
-      amount: 1
-    3:
-      material_type: mc
-      material: LIGHT_GRAY_STAINED_GLASS_PANE
-      amount: 1
-    4:
-      material_type: mc
-      material: LIGHT_GRAY_STAINED_GLASS_PANE
-      amount: 1
-    5:
-      material_type: mc
-      material: LIGHT_GRAY_STAINED_GLASS_PANE
-      amount: 1
-    6:
-      material_type: mc
-      material: LIGHT_GRAY_STAINED_GLASS_PANE
-      amount: 1
-    7:
-      material_type: mc
-      material: LIGHT_GRAY_STAINED_GLASS_PANE
-      amount: 1
-    8:
-      material_type: mc
-      material: LIGHT_GRAY_STAINED_GLASS_PANE
-      amount: 1
-    9:
-      material_type: mc
-      material: LIGHT_GRAY_STAINED_GLASS_PANE
-      amount: 1
-HAIMAN_INFO_FENZI_3:
-  lateInit: false
-  item_group: sakurafun_recipe
-  item:
-    name: '&c&l分子重组仪配方'
-    lore:
-    - '&7该物品在分子重组仪3里制作'
-    material_type: skull_hash
-    material: 5dff8dbbab15bfbb11e23b1f50b34ef548ad9832c0bd7f5a13791adad0057e1b
-    amount: 1
-  placeable: false
-  recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-HAIMAN_INFO_FENZI_4:
-  lateInit: false
-  item_group: sakurafun_recipe
-  item:
-    name: '&c&l分子重组仪配方'
-    lore:
-    - '&7该物品在分子重组仪4里制作'
-    material_type: skull_hash
-    material: 57ccd36dc8f72adcb1f8c8e61ee82cd96ead140cf2a16a1366be9b5a8e3cc3fc
-    amount: 1
-  placeable: false
-  recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-HAIMAN_INFO_FENZI_5:
-  lateInit: false
-  item_group: sakurafun_recipe
-  item:
-    name: '&4&l分子重组仪配方'
-    lore:
-    - '&7该物品在分子重组仪5里制作'
-    material_type: skull_hash
-    material: 30a35957fce2344aa8557ba6b36187ab415249934607bbbed2a053c3a86cafc0
-    amount: 1
-  placeable: false
-  recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    5:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-HAIMAN_INFO_FENZI_32767:
-  lateInit: false
-  item_group: sakurafun_recipe
-  item:
-    name: '&5&l分子重组仪配方'
-    lore:
-    - '&7该物品在分子重组仪32767里制作'
-    material_type: skull_hash
-    material: 6f89b150be9c4c5249f355f68ea0c4391300a9be1f260d750fc35a1817ad796e
-    amount: 1
-  placeable: false
-  recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-HAIMAN_INFO_FENZI_GAIZHUANG:
-  lateInit: false
-  item_group: sakurafun_recipe
-  item:
-    name: '&5&l分子重组仪改装机配方'
-    lore:
-    - '&7该物品需要在分子重组仪改装机中改装升级'
-    material_type: skull_hash
-    material: 2afeefa29bfdb3202238a2c4b8dcb750506a30d122600f88725e5aa247335460
-    amount: 1
-  placeable: false
-  recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    8:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-HAIMAN_INFO_FENZI_YEHUAJI:
-  lateInit: false
-  item_group: sakurafun_recipe
-  item:
-    name: '&5&l燃料液化机配方'
-    lore:
-    - '&7该物品需要在燃料液化机中制作'
-    material_type: skull_hash
-    material: 6080972b7c32da650cc86e9aad665ed8d0d48a3bdb0ba234d4fceac024c7952e
-    amount: 1
-  placeable: false
-  recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    8:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-HAIMAN_INFO_COFFEE_MACHINE:
-  lateInit: false
-  item_group: sakurafun_recipe
-  item:
-    name: '&c&l咖啡机配方'
-    lore:
-    - '&7该物品需要在咖啡机中制作'
-    material_type: skull_hash
-    material: 4552f7375672a5737f2ab766e5d1bcbfe8e12913cc9f044b43a2123a35185665
-    amount: 1
-  placeable: false
-  recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    8:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-HAIMAN_INFO_HAIMAN_ADVANCE_DYING:
-  lateInit: false
-  item_group: sakurafun_recipe
-  item:
-    name: '&6&l终极染坊配方'
-    lore:
-    - '&7该物品需要在终极染坊中染色'
-    material_type: skull_hash
-    material: 391255206efac82b7e5ed6ce4b1ae5669ce55d087099299811007148bd1c8ece
-    amount: 1
-  placeable: false
-  recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    8:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-HAIMAN_INFO_CHUDIAN:
-  lateInit: false
-  item_group: sakurafun_recipe
-  item:
-    name: '&6&l储电机配方'
-    lore:
-    - '&7该物品需要在储电机中充电'
-    material_type: skull_hash
-    material: 918a00b1c5ef0ba6d83e54fcbabb6272764f165d57ce8a26a916d4192a54c966
-    amount: 1
-  placeable: false
-  recipe_type: 'NULL'
-  recipe:
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    8:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-HAIMAN_INFO_GUANGDIANJUHE:
-  lateInit: false
-  item_group: sakurafun_recipe
-  item:
-    name: '&6&l电光聚合机配方'
-    lore:
-    - '&7该物品需要在电光聚合机中制作'
-    material_type: skull_hash
-    material: 366335847cba9aeaffc95cb109fdf55da13c95c97326a3bf5ddc7c99ee3
-    amount: 1
-  placeable: false
-  recipe_type: 'NULL'
-  recipe:
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    8:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-HAIMAN_INFO_GUANGDIAN:
-  lateInit: false
-  item_group: sakurafun_recipe
-  item:
-    name: '&6&l电光升级机配方'
-    lore:
-    - '&7该物品需要在电光升级机中制作'
-    material_type: skull_hash
-    material: 59d0f51f39e08e51cc83cbec01e3ce1362c70c02edc351902af8e7a5f6e201bc
-    amount: 1
-  placeable: false
-  recipe_type: 'NULL'
-  recipe:
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    8:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-HAIMAN_INFO_BIRTHDAY_CAKE_STOVE:
-  lateInit: false
-  item_group: sakurafun_recipe
-  item:
-    name: '&6&l烤箱配方'
-    lore:
-    - '&7该物品需要在烤箱中烘焙'
-    material_type: skull_hash
-    material: 8f9da46d97461a1be10600cc546a9d4613e16cfb5719eeb39042e501836008ca
-    amount: 1
-  placeable: false
-  recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    8:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-HAIMAN_INFO_WRITTEN_BOOK_CHANGER:
-  lateInit: false
-  item_group: sakurafun_recipe
-  item:
-    name: '&e&l旧书机配方'
-    lore:
-    - '&7该物品需要在旧书机中制作'
-    material_type: skull_hash
-    material: 46ee7e906686abd5ec192b079314c45f1fb8171d9e13caa4cf9f63afc2263fd5
-    amount: 1
-  placeable: false
-  recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-HAIMAN_INFO_HEIDONG:
-  lateInit: false
-  item_group: sakurafun_recipe
-  item:
-    name: '&e&l人造黑洞配方'
-    lore:
-    - '&7该物品需要在人造黑洞中制作'
-    material_type: skull_hash
-    material: 65333ccc4075cef0de045b090a72b4fd5417f91e9e908b623fbbe48766d2aff5
-    amount: 1
-  placeable: false
-  recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
 HM_COMMAND_BLOCK:
   lateInit: false
   item_group: slime_customizer_yuanban
   item:
     name: '&f&l命令方块'
     lore:
-    - '&7该物品需要在3级及以上分子重组仪中制作'
+      - '&7该物品需要在3级及以上分子重组仪中制作'
     material_type: mc
     material: COMMAND_BLOCK
     amount: 1
   placeable: false
   recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
 HM_LS_XH_COMMAND_BLOCK:
   lateInit: false
   item_group: slime_customizer_yuanban
   item:
     name: '&f&l连锁型/循环型命令方块'
     lore:
-    - '&7该物品需要命令方块染色机中制作'
+      - '&7该物品需要命令方块染色机中制作'
     material_type: mc
     material: REPEATING_COMMAND_BLOCK
     amount: 1
   placeable: false
   recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
 HM_JG_PT:
   lateInit: false
   item_group: slime_customizer_yuanban
   item:
     name: '&f&l结构方块/拼图方块'
     lore:
-    - '&7该物品需要在3级及以上分子重组仪中制作'
+      - '&7该物品需要在3级及以上分子重组仪中制作'
     material_type: mc
     material: STRUCTURE_BLOCK
     amount: 1
   placeable: false
   recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
 HM_JGKW:
   lateInit: false
   item_group: slime_customizer_yuanban
   item:
     name: '&f&l结构空位'
     lore:
-    - '&7该物品需要在3级及以上分子重组仪中制作'
+      - '&7该物品需要在3级及以上分子重组仪中制作'
     material_type: mc
     material: STRUCTURE_VOID
     amount: 1
   placeable: false
   recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
 HM_PLHEAD:
   lateInit: false
   item_group: slime_customizer_yuanban
   item:
     name: '&f&l玩家头颅'
     lore:
-    - '&7该物品需要在2级及以上分子重组仪中制作'
+      - '&7该物品需要在2级及以上分子重组仪中制作'
     material_type: mc
     material: PLAYER_HEAD
     amount: 1
   placeable: false
   recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
 HM_JY_PZ:
   lateInit: false
   item_group: slime_customizer_yuanban
   item:
     name: '&f&l基岩/屏障'
     lore:
-    - '&7该物品需要在5级及以上分子重组仪中制作'
+      - '&7该物品需要在5级及以上分子重组仪中制作'
     material_type: mc
     material: BEDROCK
     amount: 1
   placeable: false
   recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
 HM_MLFKFC:
   lateInit: false
   item_group: slime_customizer_yuanban
   item:
     name: '&f&l命令方块矿车'
     lore:
-    - '&7该物品需要在矿车装配机中制作'
+      - '&7该物品需要在矿车装配机中制作'
     material_type: mc
     material: COMMAND_BLOCK_MINECART
     amount: 1
   placeable: false
   recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
 HM_ZSZZ:
   lateInit: false
   item_group: slime_customizer_yuanban
   item:
     name: '&f&l紫颂植株'
     lore:
-    - '&7该物品需要在1级及以上分子重组仪中制作'
+      - '&7该物品需要在1级及以上分子重组仪中制作'
     material_type: mc
     material: CHORUS_PLANT
     amount: 1
   placeable: false
   recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
 HM_TJ_GT:
   lateInit: false
   item_group: slime_customizer_yuanban
   item:
     name: '&f&l土径/耕土'
     lore:
-    - '&7该物品需要在土质改良机中制作'
+      - '&7该物品需要在土质改良机中制作'
     material_type: mc
     material: DIRT_PATH
     amount: 1
   placeable: false
   recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
 HM_SHMTJ:
   lateInit: false
   item_group: slime_customizer_yuanban
   item:
     name: '&f&l石化木台阶'
     lore:
-    - '&7该物品需要在石化机中制作'
+      - '&7该物品需要在石化机中制作'
     material_type: mc
     material: PETRIFIED_OAK_SLAB
     amount: 1
   placeable: false
   recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
 HM_CSFK:
   lateInit: false
   item_group: slime_customizer_yuanban
   item:
     name: '&f&l虫蚀方块'
     lore:
-    - '&7该物品需要在虫蚀机中制作'
+      - '&7该物品需要在虫蚀机中制作'
     material_type: mc
     material: INFESTED_STONE_BRICKS
     amount: 1
   placeable: false
   recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
 HM_ZSJMY:
   lateInit: false
   item_group: slime_customizer_yuanban
   item:
     name: '&f&l紫水晶母岩'
     lore:
-    - '&7该物品需要在洞穴环境模拟机中制作'
+      - '&7该物品需要在洞穴环境模拟机中制作'
     material_type: mc
     material: BUDDING_AMETHYST
     amount: 1
   placeable: false
   recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
 HM_MDCSMKJ:
   lateInit: false
   item_group: slime_customizer_yuanban
   item:
     name: '&f&l末地传送门框架'
     lore:
-    - '&7该物品需要在末地传送门框架构造机中制作'
+      - '&7该物品需要在末地传送门框架构造机中制作'
     material_type: mc
     material: END_PORTAL_FRAME
     amount: 1
   placeable: false
   recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
 HM_SGL:
   lateInit: false
   item_group: slime_customizer_yuanban
   item:
     name: '&f&l刷怪笼'
     lore:
-    - '&7该物品需要在刷怪笼构造机中制作'
+      - '&7该物品需要在刷怪笼构造机中制作'
     material_type: mc
     material: SPAWNER
     amount: 1
   placeable: false
   recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
 HM_ZSZS:
   lateInit: false
   item_group: slime_customizer_yuanban
   item:
     name: '&f&l知识之书/成书'
     lore:
-    - '&7该物品需要在书厂中制作'
+      - '&7该物品需要在书厂中制作'
     material_type: mc
     material: KNOWLEDGE_BOOK
     amount: 1
   placeable: false
   recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
 HM_DEBUG:
   lateInit: false
   item_group: slime_customizer_yuanban
   item:
     name: '&f&l调试棒/DEBUG鱼'
     lore:
-    - '&7该物品需要在Debug调试机中制作'
+      - '&7该物品需要在Debug调试机中制作'
     material_type: mc
     material: DEBUG_STICK
     amount: 1
   placeable: false
   recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
 HM_LIGHT_ZS:
   lateInit: false
   item_group: slime_customizer_yuanban
   item:
     name: '&f&l光源方块'
     lore:
-    - '&7该物品需要在电光聚合机和电光升级机中制作'
+      - '&7该物品需要在电光聚合机和电光升级机中制作'
     material_type: mc
     material: LIGHT
     amount: 1
   placeable: false
   recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
 HM_SHOUNADAI:
   lateInit: false
   item_group: slime_customizer_yuanban
   item:
     name: '&f&l收纳袋'
     lore:
-    - '&7该物品需要在海曼工作台中制作'
+      - '&7该物品需要在海曼工作台中制作'
     material_type: mc
     material: BUNDLE
     amount: 1
   placeable: false
   recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
 HM_QINGWALUAN:
   lateInit: false
   item_group: slime_customizer_yuanban
   item:
     name: '&f&l青蛙卵'
     lore:
-    - '&7该物品需要在转蛋机中制作'
+      - '&7该物品需要在转蛋机中制作'
     material_type: mc
     material: FROGSPAWN
     amount: 1
   placeable: false
   recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
 HM_QHSBY:
   lateInit: false
   item_group: slime_customizer_yuanban
   item:
     name: '&f&l强化深板岩'
     lore:
-    - '&7该物品需要在深板岩强化机中制作'
+      - '&7该物品需要在深板岩强化机中制作'
     material_type: mc
     material: REINFORCED_DEEPSLATE
     amount: 1
   placeable: false
   recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
 HM_KYDFK:
   lateInit: false
   item_group: slime_customizer_yuanban
   item:
     name: '&f&l可疑的沙子/沙砾'
     lore:
-    - '&7该物品需要在可疑的机器中制作'
+      - '&7该物品需要在可疑的机器中制作'
     material_type: mc
     material: SUSPICIOUS_SAND
     amount: 1
   placeable: false
   recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
 HM_SGD:
   lateInit: false
   item_group: slime_customizer_yuanban
   item:
     name: '&f&l刷怪蛋'
     lore:
-    - '&7该物品需要在MC生物培育箱中制作'
+      - '&7该物品需要在MC生物培育箱中制作'
     material_type: mc
     material: CHICKEN_SPAWN_EGG
     amount: 1
   placeable: false
   recipe_type: 'NULL'
-  recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
 HAIMAN_AMETHYST_DUST:
   lateInit: false
   item_group: slime_customizer_material
@@ -1534,7 +325,7 @@ HEJINDING_YUANPEI:
   item:
     name: '&6&l合金锭原胚'
     lore:
-    - '&7还需要进一步加工'
+      - '&7还需要进一步加工'
     material_type: skull_hash
     material: 6849c8563b49c5cd65066b867e99edb285da95f0fd210e23fa35b5c5c5892107
     amount: 1
@@ -1583,7 +374,7 @@ HERANLIAOYJ:
   item:
     name: '&a&l核燃料原浆'
     lore:
-    - '&7未经处理的核燃料'
+      - '&7未经处理的核燃料'
     material_type: skull_hash
     material: 9c64568adebf2844df824332dc27e4c66a8a9af6b4d752782f610db61d065
     amount: 1
@@ -1604,7 +395,7 @@ RAINBOW_ZOT:
   item:
     name: '&b&l四色粒子'
     lore:
-    - '&7由四种颜色的粒子拟合而成'
+      - '&7由四种颜色的粒子拟合而成'
     material_type: skull_hash
     material: adc84c1d9289974cc2c5390377d66629eba61d605399bea374f368255f87e3e6
     amount: 1
@@ -1633,7 +424,7 @@ ZOT_INGOT:
   item:
     name: '&b&l末地粒子锭'
     lore:
-    - '&7这是一个由多种末地粒子炼制而成的材料'
+      - '&7这是一个由多种末地粒子炼制而成的材料'
     material_type: mc
     material: NETHERITE_INGOT
     amount: 1
@@ -1682,7 +473,7 @@ YASUO_SFBOOK:
   item:
     name: '&a&l压缩粘液科技书'
     lore:
-    - '&7啊？'
+      - '&7啊？'
     material_type: mc
     material: BOOK
     amount: 1
@@ -1731,7 +522,7 @@ YASUO_YASUO_SFBOOK:
   item:
     name: '&2&l粘液科技书皮'
     lore:
-    - '&7已经被压成一张纸的厚度了'
+      - '&7已经被压成一张纸的厚度了'
     material_type: mc
     material: PAPER
     amount: 1
@@ -1748,7 +539,7 @@ FUHEBAN:
   item:
     name: '&8&l复合板'
     lore:
-    - '&7由多种合金板压制而成'
+      - '&7由多种合金板压制而成'
     material_type: mc
     material: LIGHT_GRAY_DYE
     amount: 1
@@ -1797,8 +588,8 @@ ARTIFICIAL_SILICON_BASED_MATERIALS:
   item:
     name: '&c&l人造硅基材料'
     lore:
-    - '&7这是MC历史上伟大的创新！'
-    - '&b通常用于制造精密零件与自动化机器'
+      - '&7这是MC历史上伟大的创新！'
+      - '&b通常用于制造精密零件与自动化机器'
     material_type: mc
     material: PHANTOM_MEMBRANE
     amount: 1
@@ -1847,7 +638,7 @@ MINECRAFT_SOURCE_STONE:
   item:
     name: '&d&lMinecraft源石'
     lore:
-    - '&6这是Minecraft的核心，这是Minecraft的起源'
+      - '&6这是Minecraft的核心，这是Minecraft的起源'
     material_type: mc
     material: LAPIS_LAZULI
     amount: 1
@@ -1896,7 +687,7 @@ ANCIENT_ITEM:
   item:
     name: '&6&l远古的遗物'
     lore:
-    - '&7这是从哪发掘出来的呢？'
+      - '&7这是从哪发掘出来的呢？'
     material_type: mc
     material: ANCIENT_DEBRIS
     amount: 1
@@ -1945,56 +736,24 @@ MINECRAFT_DEAD_BUSH_GHOST:
   item:
     name: '&c&l枯 死 的 灌 木'
     lore:
-    - '&7这是一个传说...'
+      - '&7这是一个传说...'
     material_type: mc
     material: DEAD_BUSH
     amount: 1
   placeable: false
-  recipe_type: 'NULL'
+  recipe_type: HAIMAN_INFO_FENZI_4
   recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
+    5:
       material_type: mc
       material: JIGSAW
       amount: 2
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_FENZI_4
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    8:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
 ULTIMATE_ENERGY_MOTOR:
   lateInit: false
   item_group: slime_customizer_material
   item:
     name: '&4&l终极能源马达'
     lore:
-    - '&8这难道就是马达的极限了？'
+      - '&8这难道就是马达的极限了？'
     material_type: skull_hash
     material: 918a00b1c5ef0ba6d83e54fcbabb6272764f165d57ce8a26a916d4192a54c966
     amount: 1
@@ -2043,7 +802,7 @@ JITANCHENZHOU:
   item:
     name: '&8&l献祭祭坛承轴'
     lore:
-    - '&7支撑祭坛运行的装置'
+      - '&7支撑祭坛运行的装置'
     material_type: skull_hash
     material: a9f3c8f48321e668ccac5300d7dc9b92a3fbe3deca2a38dd8191c68d251a4014
     amount: 1
@@ -2092,7 +851,7 @@ YJ_DINGWEI_QI:
   item:
     name: '&c&l遗迹定位器'
     lore:
-    - '&8遗迹搜寻机的核心部件'
+      - '&8遗迹搜寻机的核心部件'
     material_type: skull_hash
     material: a1af3a5286e38a73458bdf55a0d1685489b119d36ad230384a2a43f7bf413fcd
     amount: 1
@@ -2141,7 +900,7 @@ BZ_TCQ:
   item:
     name: '&4&l宝藏探测器'
     lore:
-    - '&8探测遗迹中的宝藏'
+      - '&8探测遗迹中的宝藏'
     material_type: skull_hash
     material: c3ffa9b958aacc2b3979cf63413e6cdd254340552085ff20d60404f50f3cd2c7
     amount: 1
@@ -2190,7 +949,7 @@ DOUMAOBANG:
   item:
     name: '&6&l逗猫棒'
     lore:
-    - '&8用来逗猫'
+      - '&8用来逗猫'
     material_type: mc
     material: BLAZE_ROD
     amount: 1
@@ -2239,28 +998,24 @@ HAIMAN_INFINITY_CONSTRUCTOR_2:
   item:
     name: '&f&l无尽锭压缩奇点'
     lore:
-    - '&7由32个无尽锭奇点压缩而成'
+      - '&7由32个无尽锭奇点压缩而成'
     material_type: skull_hash
     material: 8af6bd2c033a838d4ff7fd555321e06cf806a75c4a2b5868c71004e02a1860a4
     amount: 1
   placeable: false
-  recipe_type: 'NULL'
+  recipe_type: HAIMAN_INFO_FENZI_3
   recipe:
-    2:
+    5:
       material_type: slimefun
       material: INFINITY_SINGULARITY
       amount: 32
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_FENZI_3
-      amount: 1
 HM_DONGLILINGJIAN:
   lateInit: false
   item_group: slime_customizer_material
   item:
     name: '&6&l动力零件'
     lore:
-    - '&7由机器人身上拆解下来的零件'
+      - '&7由机器人身上拆解下来的零件'
     material_type: skull_hash
     material: fd880f423cc25aa86208115f57740e6627d695e71bb33fec381e4c66b20ffd72
     amount: 1
@@ -2309,8 +1064,8 @@ HM_CHAOPING_CIRCUIT_BOARD:
   item:
     name: '&4&l超频电路板'
     lore:
-    - '&8不同的材料对应不同的功能区'
-    - '&8功能性越强的机器越需要这种材料'
+      - '&8不同的材料对应不同的功能区'
+      - '&8功能性越强的机器越需要这种材料'
     material_type: skull_hash
     material: dcafbac5068197fda18636dfc4ce7f9df5af9b2a06e6f91e38ae35e4c435b2df
     amount: 1
@@ -2359,7 +1114,7 @@ DUIDIEYUANJIAN:
   item:
     name: '&5&l强制堆叠元件'
     lore:
-    - '&7打破规则，坍缩空间'
+      - '&7打破规则，坍缩空间'
     material_type: skull_hash
     material: ecfd26d73f44b14713e8decb924ea10dc359e687f8f71b57612c35ac7c8492d
     amount: 1
@@ -2408,7 +1163,7 @@ LIZI_YUANPEI:
   item:
     name: '&e&l粒子原胚'
     lore:
-    - '&7主世界自动化粒子的基础'
+      - '&7主世界自动化粒子的基础'
     material_type: skull_hash
     material: 5d63fd3d50e2aabdf8da463b939c57b24d5fd20b519dfdb9ce84e96b0ee3239b
     amount: 1
@@ -2457,84 +1212,68 @@ MAGIC_SWEET_POTATO:
   item:
     name: '&6&l魔芋'
     lore:
-    - '&7记忆溯流中的强烈波涌...'
+      - '&7记忆溯流中的强烈波涌...'
     material_type: skull_hash
     material: 454f2bc3ecf5075d0dde8a4a482f5ada21d3a6856bc7bfad51bbbc003c86c543
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
+  recipe_type: HAIMAN_INFO_FENZI_32767
   recipe:
-    2:
+    5:
       material_type: mc
       material: APPLE
       amount: 64
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_FENZI_32767
-      amount: 1
 FKS:
   lateInit: false
   item_group: slime_customizer_zhuangshi
   item:
     name: '&6&l方块树'
     lore:
-    - '&7记忆溯流中的一股浪潮...'
+      - '&7记忆溯流中的一股浪潮...'
     material_type: skull_hash
     material: cdfd5bf1ff0543147c9d64e68761db6e4b7132ac658f0b8f79831fad9c289eca
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
+  recipe_type: HAIMAN_INFO_FENZI_32767
   recipe:
-    2:
+    5:
       material_type: mc
       material: OAK_SAPLING
       amount: 64
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_FENZI_32767
-      amount: 1
 HAIMAN:
   lateInit: false
   item_group: slime_customizer_zuozhe
   item:
     name: '&e&lhaiman的头'
     lore:
-    - '&7海曼科技院作者——haiman'
+      - '&7海曼科技院作者——haiman'
     material_type: skull_hash
     material: 1421f1514da756c8c6c7c0b83a79265c26c9ece66b3bad8fbd94bd96d7040d7e
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
+  recipe_type: HAIMAN_INFO_HAIMAN_ADVANCE_DYING
   recipe:
-    2:
+    5:
       material_type: mc
       material: CREEPER_HEAD
       amount: 4
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_HAIMAN_ADVANCE_DYING
-      amount: 1
 YITOUDAIDAI:
   lateInit: false
   item_group: slime_customizer_zuozhe
   item:
     name: '&e&lyitoudaidai的头'
     lore:
-    - '&7原宇宙科技作者——yitoudaidai'
+      - '&7原宇宙科技作者——yitoudaidai'
     material_type: skull_hash
     material: a2ac9cbc5befca3a8007a6d0b54b626459d0d510203ea1563a09883a525a747c
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
+  recipe_type: HAIMAN_INFO_HAIMAN_ADVANCE_DYING
   recipe:
-    2:
+    5:
       material_type: mc
       material: SKELETON_SKULL
       amount: 4
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_HAIMAN_ADVANCE_DYING
-      amount: 1
 YH_MC:
   lateInit: false
   item_group: slime_customizer_zuozhe
@@ -2543,102 +1282,82 @@ YH_MC:
     material: yh_mc
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
+  recipe_type: HAIMAN_INFO_HAIMAN_ADVANCE_DYING
   recipe:
-    2:
+    5:
       material_type: mc
       material: DIAMOND
       amount: 64
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_HAIMAN_ADVANCE_DYING
-      amount: 1
 H_FUEL:
   lateInit: false
   item_group: slime_customizer_material
   item:
     name: '&2&l氚氘重水复合燃料'
     lore:
-    - '&7一种高能燃料'
-    - '&7似乎能稍微缓解能源问题'
+      - '&7一种高能燃料'
+      - '&7似乎能稍微缓解能源问题'
     material_type: skull_hash
     material: 51e1078c12a91c780a7db1a81af1b9ea90eca9a97dee104115b2408895e4a572
     amount: 1
   placeable: false
-  recipe_type: 'NULL'
+  recipe_type: HAIMAN_INFO_FENZI_YEHUAJI
   recipe:
-    2:
+    5:
       material_type: slimefun
       material: PLUTONIUM
       amount: 16
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_FENZI_YEHUAJI
-      amount: 1
 HD_FUEL:
   lateInit: false
   item_group: slime_customizer_material
   item:
     name: '&d&l液化磁单极子燃料'
     lore:
-    - '&7利用宇宙中的粒子制成燃料'
-    - '&7是未来主要超高能燃料之一'
+      - '&7利用宇宙中的粒子制成燃料'
+      - '&7是未来主要超高能燃料之一'
     material_type: skull_hash
     material: be64ff0a2d427344b9349c8dea6f4a4cb7caccdb6f8f877c3e47bcbb42132325
     amount: 1
   placeable: false
-  recipe_type: 'NULL'
+  recipe_type: HAIMAN_INFO_FENZI_YEHUAJI
   recipe:
-    2:
+    5:
       material_type: slimefun
       material: ZOT_INGOT
       amount: 16
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_FENZI_YEHUAJI
-      amount: 1
 HDB_FUEL:
   lateInit: false
   item_group: slime_customizer_material
   item:
     name: '&8&l负能反物质离子燃料'
     lore:
-    - '&7人们探测到了黑洞周围尚存的微粒'
-    - '&7并把它们制成了燃料'
+      - '&7人们探测到了黑洞周围尚存的微粒'
+      - '&7并把它们制成了燃料'
     material_type: skull_hash
     material: 9e162daa331c6cf8d6138b83fb848bd35c78d2f5f2199de6e9e18a4388265b7
     amount: 1
   placeable: false
-  recipe_type: 'NULL'
+  recipe_type: HAIMAN_INFO_FENZI_YEHUAJI
   recipe:
-    2:
+    5:
       material_type: slimefun
       material: MINECRAFT_DEAD_BUSH_GHOST
       amount: 2
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_FENZI_YEHUAJI
-      amount: 1
 HDBU_FUEL:
   lateInit: false
   item_group: slime_customizer_material
   item:
     name: '&8&l暗能宇宙墙燃料'
     lore:
-    - '&7一种用宇宙墙物质制成的燃料'
+      - '&7一种用宇宙墙物质制成的燃料'
     material_type: skull_hash
     material: 4618992e18cd67b026659e50b130b3b251789e0b91bd16be4b7e59697a68d7a
     amount: 1
   placeable: false
-  recipe_type: 'NULL'
+  recipe_type: HAIMAN_INFO_FENZI_YEHUAJI
   recipe:
-    2:
-      material_type: slimefun
-      material: MINECRAFT_SOURCE_STONE
-      amount: 1
     5:
       material_type: slimefun
-      material: HAIMAN_INFO_FENZI_YEHUAJI
+      material: MINECRAFT_SOURCE_STONE
       amount: 1
 HAIMAN_GALAXY_PIECE:
   lateInit: false
@@ -2646,20 +1365,16 @@ HAIMAN_GALAXY_PIECE:
   item:
     name: '&d&l银河碎片'
     lore:
-    - '&7据说是一股强大的能量将银河破碎了'
+      - '&7据说是一股强大的能量将银河破碎了'
     material_type: mc
     material: BLUE_DYE
     amount: 1
   placeable: false
-  recipe_type: 'NULL'
+  recipe_type: HAIMAN_INFO_FENZI_4
   recipe:
-    2:
+    5:
       material_type: saveditem
       material: 0
-      amount: 1
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_FENZI_4
       amount: 1
 HAIMAN_BLACK_HOLE_PIECE:
   lateInit: false
@@ -2667,70 +1382,58 @@ HAIMAN_BLACK_HOLE_PIECE:
   item:
     name: '&8&l黑洞碎片'
     lore:
-    - '&7黑洞神秘的引力将它们聚集在一起'
+      - '&7黑洞神秘的引力将它们聚集在一起'
     material_type: mc
     material: BLACK_DYE
     amount: 1
   placeable: false
-  recipe_type: 'NULL'
+  recipe_type: HAIMAN_INFO_FENZI_5
   recipe:
-    2:
+    5:
       material_type: slimefun
       material: HAIMAN_GALAXY_PIECE
       amount: 16
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_FENZI_5
-      amount: 1
 DOGE:
   lateInit: false
   item_group: slime_customizer_emoji
   item:
     name: '&c&lDOGE'
     lore:
-    - '&7狗头保命！'
+      - '&7狗头保命！'
     material_type: skull_hash
     material: a374fd6d1448fa130e9249af199023846b8fc877f117f3ac1c43403ba7fef3
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
+  recipe_type: HAIMAN_INFO_FENZI_32767
   recipe:
-    2:
+    5:
       material_type: mc
       material: BONE
       amount: 64
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_FENZI_32767
-      amount: 1
 HAIMAN_TEA:
   lateInit: false
   item_group: slime_customizer_zhuangshi
   item:
     name: '&a&l星巴克奶茶'
     lore:
-    - '&7三点几嘞！饮茶先嘞！'
+      - '&7三点几嘞！饮茶先嘞！'
     material_type: skull_hash
     material: d672c57f4c7b9e962b45b55dd7bd7886880d7eef26db6c2cce03c8ff8c48
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
+  recipe_type: HAIMAN_INFO_FENZI_32767
   recipe:
-    2:
+    5:
       material_type: mc
       material: FERN
       amount: 64
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_FENZI_32767
-      amount: 1
 EMOJI_HAPPY:
   lateInit: false
   item_group: slime_customizer_emoji
   item:
     name: '&e&l开心黄豆'
     lore:
-    - '&7好嗨哟！'
+      - '&7好嗨哟！'
     material_type: skull_hash
     material: 3baabe724eae59c5d13f442c7dc5d2b1c6b70c2f83364a488ce5973ae80b4c3
     amount: 1
@@ -2779,7 +1482,7 @@ EMOJI_NERVOUS:
   item:
     name: '&e&l流汗黄豆'
     lore:
-    - '&7az'
+      - '&7az'
     material_type: skull_hash
     material: 6ccd5472a46f46e4cdfda9adea2320cccfbae11198b6aae163d17c4b5b4666d
     amount: 1
@@ -2828,7 +1531,7 @@ EMOJI_ANGRY:
   item:
     name: '&4&l愤怒黄豆'
     lore:
-    - '&7气死偶咧！(╬◣д◢)'
+      - '&7气死偶咧！(╬◣д◢)'
     material_type: skull_hash
     material: 4fb97b17c6395392658f32718aa46befa1c31d3572651c30f7d2bf3b93f6ead9
     amount: 1
@@ -2877,7 +1580,7 @@ EMOJI_ICE:
   item:
     name: '&4&l寒冰黄豆'
     lore:
-    - '&7冻死我了...'
+      - '&7冻死我了...'
     material_type: skull_hash
     material: 46a77dfed8297dc44dad6f29faf7277dfa98eafbb53fa66c7730a50e3818484b
     amount: 1
@@ -2926,7 +1629,7 @@ EMOJI_ZZZ:
   item:
     name: '&e&l睡觉黄豆'
     lore:
-    - '&7ZZZZZZZZ...'
+      - '&7ZZZZZZZZ...'
     material_type: skull_hash
     material: 9c4a41554342b2cbfbd895e9ec7089ae861fec8f51693822ec1eb3ca3f18
     amount: 1
@@ -2975,7 +1678,7 @@ EMOJI_OU:
   item:
     name: '&e&l呕吐黄豆'
     lore:
-    - '&7呕!'
+      - '&7呕!'
     material_type: skull_hash
     material: aabfabf0adb2a615e901fe0040e322c51fb7d11c82cfafa21e5221a5f6a2e030
     amount: 1
@@ -3024,7 +1727,7 @@ EMOJI_LAUGH:
   item:
     name: '&e&l大笑黄豆'
     lore:
-    - '&7啊哈哈哈哈哈哈哈!'
+      - '&7啊哈哈哈哈哈哈哈!'
     material_type: skull_hash
     material: 5059d59eb4e59c31eecf9ece2f9cf3934e45c0ec476fc86bfaef8ea913ea710
     amount: 1
@@ -3073,7 +1776,7 @@ EMOJI_LAUGHING_CRYING:
   item:
     name: '&e&l笑哭黄豆'
     lore:
-    - '&7啊哈哈呜呜!'
+      - '&7啊哈哈呜呜!'
     material_type: skull_hash
     material: c2767e93720a81000cdb11bffe82f1ee6a67fbbc49576b0e4b403f0321e36f62
     amount: 1
@@ -3122,7 +1825,7 @@ EMOJI_SAD:
   item:
     name: '&e&l伤心黄豆'
     lore:
-    - '&7嘤嘤嘤!'
+      - '&7嘤嘤嘤!'
     material_type: skull_hash
     material: 1c2672aaae58f3d1852d19b8422caf70b32582f8de3fcb5c7c24dacb7ebc3
     amount: 1
@@ -3171,7 +1874,7 @@ EMOJI_CRY:
   item:
     name: '&e&l大哭黄豆'
     lore:
-    - '&7呜呜呜呜呜!'
+      - '&7呜呜呜呜呜!'
     material_type: skull_hash
     material: 3255846467f33937db9f43cdfb34a0dfd12f57522e8a988e458b5ac3c134e
     amount: 1
@@ -3220,7 +1923,7 @@ EMOJI_SHIT:
   item:
     name: '&e&l狗屎黄豆'
     lore:
-    - '&7吔屎啦你!'
+      - '&7吔屎啦你!'
     material_type: skull_hash
     material: f650232c1d8b337965087693449c02c960ca4393b048346a4f0b2e18e58fa
     amount: 1
@@ -3269,7 +1972,7 @@ EMOJI_WOW:
   item:
     name: '&e&l惊讶黄豆'
     lore:
-    - '&7这是什么骚操作!'
+      - '&7这是什么骚操作!'
     material_type: skull_hash
     material: f720df911c052377065408db78a25c678f791eb944c063935ae86dbe51c71b
     amount: 1
@@ -3318,7 +2021,7 @@ EMOJI_CRAZY:
   item:
     name: '&e&l阿巴阿巴黄豆'
     lore:
-    - '&7睿智的眼神!'
+      - '&7睿智的眼神!'
     material_type: skull_hash
     material: 71becacec858a19848860b2522c32936adf1588c1ef42379403fef83da4bb
     amount: 1
@@ -3367,7 +2070,7 @@ EMOJI_LOVE:
   item:
     name: '&e&l亲亲黄豆'
     lore:
-    - '&7❥ლ(°◕‵ƹ′◕ლ)'
+      - '&7❥ლ(°◕‵ƹ′◕ლ)'
     material_type: skull_hash
     material: 545bd18a2aaf469fad72e52cde6cfb02bfbaa5bfed2a8151277f779ebcdcec1
     amount: 1
@@ -3416,7 +2119,7 @@ EMOJI_LUE:
   item:
     name: '&e&l吐舌黄豆'
     lore:
-    - '&7略略略！'
+      - '&7略略略！'
     material_type: skull_hash
     material: 5f15c9b8edc5629b6caa49148a20c5890853c2674385e43876ca56d1d465f
     amount: 1
@@ -3465,7 +2168,7 @@ EMOJI_CONFIDENCE:
   item:
     name: '&e&l歪嘴黄豆'
     lore:
-    - '&7歪嘴战神！'
+      - '&7歪嘴战神！'
     material_type: skull_hash
     material: 44c8cd31bac657a3f26b52e262c83eb8338d56651fd22c1633565f3dbbc45777
     amount: 1
@@ -3514,7 +2217,7 @@ EMOJI_DEAD:
   item:
     name: '&e&l嗝屁黄豆'
     lore:
-    - '&7这操作...直接给我送走了！'
+      - '&7这操作...直接给我送走了！'
     material_type: skull_hash
     material: b371e4e1cf6a1a36fdae27137fd9b8748e6169299925f9af2be301e54298c73
     amount: 1
@@ -3563,7 +2266,7 @@ EMOJI_THINKING:
   item:
     name: '&e&l思索黄豆'
     lore:
-    - '&7emmm，容我想想！'
+      - '&7emmm，容我想想！'
     material_type: skull_hash
     material: 1fea99ad95b570175fda25c3a69788d6a9b854aa13f8a5ff63f6efedf581dfb6
     amount: 1
@@ -3612,7 +2315,7 @@ EMOJI_EMOTICON_EYES:
   item:
     name: '&e&l卡姿兰大眼睛黄豆'
     lore:
-    - '&7就这样看着你...看着你'
+      - '&7就这样看着你...看着你'
     material_type: skull_hash
     material: bb2aef7da8fc1cb76edc1080fc2b4145e8d86782b7cd7358b1d65b652fd98c2
     amount: 1
@@ -3661,7 +2364,7 @@ EMOJI_XOK:
   item:
     name: '&e&l恐怖黄豆'
     lore:
-    - '&7嗷呜...嘶'
+      - '&7嗷呜...嘶'
     material_type: skull_hash
     material: 8ef97ddac7b83e56b90496ed0b3d6951a385236585b489f67acfef51ca7a63a7
     amount: 1
@@ -3710,7 +2413,7 @@ EMOJI_BIG_MOUTH_CRYING:
   item:
     name: '&e&l痛哭大嘴黄豆'
     lore:
-    - '&7啊啊啊啊呜呜呜呜啊啊啊'
+      - '&7啊啊啊啊呜呜呜呜啊啊啊'
     material_type: skull_hash
     material: 5f6168dc202c049fbdd1b352176e198094bf7d1fac56240b5ea2b09b2fa5428a
     amount: 1
@@ -3759,7 +2462,7 @@ EMOJI_COOL:
   item:
     name: '&e&l墨镜黄豆'
     lore:
-    - '&7带着我漂亮的小墨镜！'
+      - '&7带着我漂亮的小墨镜！'
     material_type: skull_hash
     material: 2d2175ebe9ae0e1a658d9af82dacfb8369052d8121d4ea3886738a1cca5
     amount: 1
@@ -3808,7 +2511,7 @@ EMOJI_BEARD:
   item:
     name: '&e&l胡子黄豆'
     lore:
-    - '&7小胡子...嘿嘿！'
+      - '&7小胡子...嘿嘿！'
     material_type: skull_hash
     material: 3636f2724aa6aa4de7ac46c19f3c845fb14847a518c8f7e03d792c82effb1
     amount: 1
@@ -3857,52 +2560,20 @@ HAIMAN_ELECTRIC_ENERGY:
   item:
     name: '&e&l元电荷'
     lore:
-    - '&7它表示最小电荷量'
-    - '&7但在Minecraft中'
-    - '&7也可储存一定电能'
-    - '&8e=1.60x10∧-19C'
-    - '&b可储存: &9250J'
+      - '&7它表示最小电荷量'
+      - '&7但在Minecraft中'
+      - '&7也可储存一定电能'
+      - '&8e=1.60x10∧-19C'
+      - '&b可储存: &9250J'
     material_type: skull_hash
     material: 3420cdf2af57cc757773ace3f1915cb72b5432a2fda3373b1678f98bea7ac7
     amount: 1
   placeable: false
-  recipe_type: 'NULL'
+  recipe_type: HAIMAN_INFO_CHUDIAN
   recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: STONE_CHUNK
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
     5:
       material_type: slimefun
-      material: HAIMAN_INFO_CHUDIAN
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    8:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
+      material: STONE_CHUNK
       amount: 1
 EMOJI_SPIKE:
   lateInit: false
@@ -3910,8 +2581,8 @@ EMOJI_SPIKE:
   item:
     name: '&e&l斯派克黄豆'
     lore:
-    - '&7荒野乱斗的标志！'
-    - '&7可爱的斯派克(*╹▽╹*)'
+      - '&7荒野乱斗的标志！'
+      - '&7可爱的斯派克(*╹▽╹*)'
     material_type: skull_hash
     material: 8d8f5fb387ca66fc2f65b91fcb231604548e8565895bb96c676984205e6f19
     amount: 1
@@ -3960,8 +2631,8 @@ HAIMAN_ELECTRIC_UNIT_EMPTY:
   item:
     name: '&a&l海曼电单元 &8(空)'
     lore:
-    - '&7可放入储电机中储电'
-    - '&b可储存: &91136J'
+      - '&7可放入储电机中储电'
+      - '&b可储存: &91136J'
     material_type: skull_hash
     material: 5c3f45c14e63710f3fc5d739837dd70e37835e639a16245e50b3dd83ee8085e3
     amount: 1
@@ -4010,8 +2681,8 @@ KULUN_ELECTRIC_UNIT_EMPTY:
   item:
     name: '&a&l库伦电单元 &8(空)'
     lore:
-    - '&7可放入储电机中储电'
-    - '&b可储存: &920456J'
+      - '&7可放入储电机中储电'
+      - '&b可储存: &920456J'
     material_type: skull_hash
     material: 43b8a32356d1ad99e31799db8d69d5588e9aff9290a044ca9b2359b7523ea39c
     amount: 1
@@ -4060,8 +2731,8 @@ LEIYI_ELECTRIC_UNIT_EMPTY:
   item:
     name: '&a&l雷伊电单元 &8(空)'
     lore:
-    - '&7可放入储电机中储电'
-    - '&b可储存: &96628035J'
+      - '&7可放入储电机中储电'
+      - '&b可储存: &96628035J'
     material_type: skull_hash
     material: 8d2c19b442541351a6b81eeb6cbef41966ffb7dbe4c136b87f5baf9d14a
     amount: 1
@@ -4110,8 +2781,8 @@ INFINITE_ELECTRIC_UNIT_EMPTY:
   item:
     name: '&a&l无尽电单元 &8(空)'
     lore:
-    - '&7可放入储电机中储电'
-    - '&b可储存: &9119304647J'
+      - '&7可放入储电机中储电'
+      - '&b可储存: &9119304647J'
     material_type: skull_hash
     material: de9e060261e6cab97d6292ee230b8e4fcfb23e172ea91ecf14684ae8cfb74bdf
     amount: 1
@@ -4160,8 +2831,8 @@ LIANGZI_ELECTRIC_UNIT_EMPTY:
   item:
     name: '&a&l量子电单元 &8(空)'
     lore:
-    - '&7可放入储电机中储电'
-    - '&b可储存: &92147483647J'
+      - '&7可放入储电机中储电'
+      - '&b可储存: &92147483647J'
     material_type: skull_hash
     material: dcd7a00de13ec9f3c59d7cf902d980f5d29002c0dad754acbda0f6c2b698fd05
     amount: 1
@@ -4210,49 +2881,17 @@ HAIMAN_ELECTRIC_UNIT_FULL:
   item:
     name: '&a&l海曼电单元 &8(满)'
     lore:
-    - '&7可放入卸电机中卸电'
-    - '&b可储存: &91136J'
+      - '&7可放入卸电机中卸电'
+      - '&b可储存: &91136J'
     material_type: skull_hash
     material: 8431a1992ba53520e504eedfeb2d7261e0ba2d5a28f59d03a669b0ad03a442d5
     amount: 1
   placeable: false
-  recipe_type: 'NULL'
+  recipe_type: HAIMAN_INFO_CHUDIAN
   recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: HAIMAN_ELECTRIC_UNIT_EMPTY
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
     5:
       material_type: slimefun
-      material: HAIMAN_INFO_CHUDIAN
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    8:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
+      material: HAIMAN_ELECTRIC_UNIT_EMPTY
       amount: 1
 KULUN_ELECTRIC_UNIT_FULL:
   lateInit: false
@@ -4260,49 +2899,17 @@ KULUN_ELECTRIC_UNIT_FULL:
   item:
     name: '&a&l库伦电单元 &8(满)'
     lore:
-    - '&7可放入卸电机中卸电'
-    - '&b可储存: &920456J'
+      - '&7可放入卸电机中卸电'
+      - '&b可储存: &920456J'
     material_type: skull_hash
     material: 1ead4e8ae8eb454dbd985bb59c4c1375945aafd28a4eccf71e8d57fc978ef5
     amount: 1
   placeable: false
-  recipe_type: 'NULL'
+  recipe_type: HAIMAN_INFO_CHUDIAN
   recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: KULUN_ELECTRIC_UNIT_EMPTY
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
     5:
       material_type: slimefun
-      material: HAIMAN_INFO_CHUDIAN
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    8:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
+      material: KULUN_ELECTRIC_UNIT_EMPTY
       amount: 1
 LEIYI_ELECTRIC_UNIT_FULL:
   lateInit: false
@@ -4310,49 +2917,17 @@ LEIYI_ELECTRIC_UNIT_FULL:
   item:
     name: '&a&l雷伊电单元 &8(满)'
     lore:
-    - '&7可放入卸电机中卸电'
-    - '&b可储存: &96628035J'
+      - '&7可放入卸电机中卸电'
+      - '&b可储存: &96628035J'
     material_type: skull_hash
     material: 516b68376c181c9a7343fee3697faacec35129fb64de5914bdbf869c652c
     amount: 1
   placeable: false
-  recipe_type: 'NULL'
+  recipe_type: HAIMAN_INFO_CHUDIAN
   recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: LEIYI_ELECTRIC_UNIT_EMPTY
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
     5:
       material_type: slimefun
-      material: HAIMAN_INFO_CHUDIAN
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    8:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
+      material: LEIYI_ELECTRIC_UNIT_EMPTY
       amount: 1
 INFINITE_ELECTRIC_UNIT_FULL:
   lateInit: false
@@ -4360,49 +2935,17 @@ INFINITE_ELECTRIC_UNIT_FULL:
   item:
     name: '&a&l无尽电单元 &8(满)'
     lore:
-    - '&7可放入卸电机中卸电'
-    - '&b可储存: &9119304647J'
+      - '&7可放入卸电机中卸电'
+      - '&b可储存: &9119304647J'
     material_type: skull_hash
     material: 31a3cd9b016b1228ec01fd6f0992c64f3b9b7b29773fa46439ab3f3c8a347704
     amount: 1
   placeable: false
-  recipe_type: 'NULL'
+  recipe_type: HAIMAN_INFO_CHUDIAN
   recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: INFINITE_ELECTRIC_UNIT_EMPTY
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
     5:
       material_type: slimefun
-      material: HAIMAN_INFO_CHUDIAN
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    8:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
+      material: INFINITE_ELECTRIC_UNIT_EMPTY
       amount: 1
 LIANGZI_ELECTRIC_UNIT_FULL:
   lateInit: false
@@ -4410,49 +2953,17 @@ LIANGZI_ELECTRIC_UNIT_FULL:
   item:
     name: '&a&l量子电单元 &8(满)'
     lore:
-    - '&7可放入卸电机中卸电'
-    - '&b可储存: &92147483647J'
+      - '&7可放入卸电机中卸电'
+      - '&b可储存: &92147483647J'
     material_type: skull_hash
     material: 2afeefa29bfdb3202238a2c4b8dcb750506a30d122600f88725e5aa247335460
     amount: 1
   placeable: false
-  recipe_type: 'NULL'
+  recipe_type: HAIMAN_INFO_CHUDIAN
   recipe:
-    1:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    2:
-      material_type: slimefun
-      material: LIANGZI_ELECTRIC_UNIT_EMPTY
-      amount: 1
-    3:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    4:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
     5:
       material_type: slimefun
-      material: HAIMAN_INFO_CHUDIAN
-      amount: 1
-    6:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    7:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    8:
-      material_type: slimefun
-      material: ZHANWEIFU
-      amount: 1
-    9:
-      material_type: slimefun
-      material: ZHANWEIFU
+      material: LIANGZI_ELECTRIC_UNIT_EMPTY
       amount: 1
 NANJING_MASSACRE_MONUMENT:
   lateInit: false
@@ -4460,10 +2971,10 @@ NANJING_MASSACRE_MONUMENT:
   item:
     name: '&8&l南京大屠杀纪念碑'
     lore:
-    - '&7勿忘国耻，铭记历史'
-    - '&7勿忘那30万永远沉睡的南京同胞们'
-    - '&7勿忘战争给世界人民带来的灾难'
-    - '&81937.12.13'
+      - '&7勿忘国耻，铭记历史'
+      - '&7勿忘那30万永远沉睡的南京同胞们'
+      - '&7勿忘战争给世界人民带来的灾难'
+      - '&81937.12.13'
     material_type: skull_hash
     material: b7cab56c82cb81bdb9979a464bc9d3ba3e6722ba122cf6c52873010a2b59aefe
     amount: 1
@@ -4475,7 +2986,7 @@ HM_CAKE_BREAD:
   item:
     name: '&e&l蛋糕坯'
     lore:
-    - '&7用于制作蛋糕'
+      - '&7用于制作蛋糕'
     material_type: skull_hash
     material: 8939e624850bb3e11da37eb549423de11e60f7f5762a5deae959453e6aee4079
     amount: 1
@@ -4524,7 +3035,7 @@ HM_EMPTY_COUNTRY_BALL:
   item:
     name: '&f&l空球模板'
     lore:
-    - '&7用于制作波兰球'
+      - '&7用于制作波兰球'
     material_type: skull_hash
     material: caf039bec1fc1fb75196092b26e631f37a87dff143fc18297798d47c5eaaf
     amount: 1
@@ -4573,28 +3084,24 @@ HAIMAN_BIRTHDAY_CAKE_1:
   item:
     name: '&6&l海曼生日蛋糕'
     lore:
-    - '&7生日快乐！'
+      - '&7生日快乐！'
     material_type: skull_hash
     material: 7ef2da482579136749ae739835c793fe28e42fb0aca520a091637b46ca0ab
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
+  recipe_type: HAIMAN_INFO_BIRTHDAY_CAKE_STOVE
   recipe:
-    2:
+    5:
       material_type: slimefun
       material: HM_CAKE_BREAD
       amount: 10
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_BIRTHDAY_CAKE_STOVE
-      amount: 1
 HAIMAN_CHINESE_DRAGON_1:
   lateInit: false
   item_group: slime_customizer_newyear
   item:
     name: '&4&l中国龙'
     lore:
-    - '&7新年快乐！'
+      - '&7新年快乐！'
     material_type: skull_hash
     material: e715a045a481cb8a39e39149020ab1440502fa1cfece6fb3ccbf53d61e49ea
     amount: 1
@@ -4643,7 +3150,7 @@ HAIMAN_TIGER_1:
   item:
     name: '&6&l虎'
     lore:
-    - '&7新年快乐！'
+      - '&7新年快乐！'
     material_type: skull_hash
     material: e060f00287e3767699ea79197eb4534345478fadf1cd53a7f81101d92
     amount: 1
@@ -4692,7 +3199,7 @@ HAIMAN_CHINA_1:
   item:
     name: '&a&l青花瓷'
     lore:
-    - '&7景德镇产'
+      - '&7景德镇产'
     material_type: skull_hash
     material: 45ca5e85c4aea608bd3443cabdf1c2bdde3b431ad3aa38fffe04a32eb7e525
     amount: 1
@@ -4741,7 +3248,7 @@ HAIMAN_CHINESE_LANTERN_1:
   item:
     name: '&4&l中国灯笼'
     lore:
-    - '&7新年快乐！'
+      - '&7新年快乐！'
     material_type: skull_hash
     material: 26283e7a88d32719304a37ede0c6a8c5dc9d9cf9b00a179cf904e8ce821312
     amount: 1
@@ -4790,7 +3297,7 @@ HAIMAN_TIGER_FURRY_1:
   item:
     name: '&c&l虎绒'
     lore:
-    - '&7一种珍奇的材料'
+      - '&7一种珍奇的材料'
     material_type: mc
     material: ORANGE_DYE
     amount: 1
@@ -4807,7 +3314,7 @@ HAIMAN_NEW_YEAR_PIECE_1:
   item:
     name: '&d&l新年碎片'
     lore:
-    - '&7破碎的年味等待愈合...'
+      - '&7破碎的年味等待愈合...'
     material_type: mc
     material: RED_DYE
     amount: 1
@@ -4856,7 +3363,7 @@ HAIMAN_NEW_YEAR_1:
   item:
     name: '&d&l新年'
     lore:
-    - '&7多少代人的梦想啊...'
+      - '&7多少代人的梦想啊...'
     material_type: skull_hash
     material: 77313f6e6652ed47d7064e83eb08ffa11b55dc5d52d6f78189701d9c2b8ec88
     amount: 1
@@ -5081,7 +3588,7 @@ CAO_TC:
   item:
     name: '&7&l机器槽填充物'
     lore:
-    - '&7用于填充不必要的输入槽与输出槽'
+      - '&7用于填充不必要的输入槽与输出槽'
     material_type: mc
     material: GRAY_STAINED_GLASS_PANE
     amount: 8
@@ -5108,16 +3615,7 @@ LIGHT_0:
     material: LIGHT_0
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
-  recipe:
-    2:
-      material_type: slimefun
-      material: HAIMAN_INFO_GUANGDIANJUHE
-      amount: 1
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_GUANGDIAN
-      amount: 1
+  recipe_type: HAIMAN_INFO_GUANGDIANJUHE
 LIGHT_1:
   lateInit: false
   item_group: slime_customizer_zhuangshi
@@ -5126,12 +3624,7 @@ LIGHT_1:
     material: LIGHT_1
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
-  recipe:
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_GUANGDIAN
-      amount: 1
+  recipe_type: HAIMAN_INFO_GUANGDIAN
 LIGHT_2:
   lateInit: false
   item_group: slime_customizer_zhuangshi
@@ -5140,12 +3633,7 @@ LIGHT_2:
     material: LIGHT_2
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
-  recipe:
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_GUANGDIAN
-      amount: 1
+  recipe_type: HAIMAN_INFO_GUANGDIAN
 LIGHT_3:
   lateInit: false
   item_group: slime_customizer_zhuangshi
@@ -5154,12 +3642,7 @@ LIGHT_3:
     material: LIGHT_3
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
-  recipe:
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_GUANGDIAN
-      amount: 1
+  recipe_type: HAIMAN_INFO_GUANGDIAN
 LIGHT_4:
   lateInit: false
   item_group: slime_customizer_zhuangshi
@@ -5168,12 +3651,7 @@ LIGHT_4:
     material: LIGHT_4
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
-  recipe:
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_GUANGDIAN
-      amount: 1
+  recipe_type: HAIMAN_INFO_GUANGDIAN
 LIGHT_5:
   lateInit: false
   item_group: slime_customizer_zhuangshi
@@ -5182,12 +3660,7 @@ LIGHT_5:
     material: LIGHT_5
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
-  recipe:
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_GUANGDIAN
-      amount: 1
+  recipe_type: HAIMAN_INFO_GUANGDIAN
 LIGHT_6:
   lateInit: false
   item_group: slime_customizer_zhuangshi
@@ -5196,12 +3669,7 @@ LIGHT_6:
     material: LIGHT_6
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
-  recipe:
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_GUANGDIAN
-      amount: 1
+  recipe_type: HAIMAN_INFO_GUANGDIAN
 LIGHT_7:
   lateInit: false
   item_group: slime_customizer_zhuangshi
@@ -5210,12 +3678,7 @@ LIGHT_7:
     material: LIGHT_7
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
-  recipe:
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_GUANGDIAN
-      amount: 1
+  recipe_type: HAIMAN_INFO_GUANGDIAN
 LIGHT_8:
   lateInit: false
   item_group: slime_customizer_zhuangshi
@@ -5224,12 +3687,7 @@ LIGHT_8:
     material: LIGHT_8
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
-  recipe:
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_GUANGDIAN
-      amount: 1
+  recipe_type: HAIMAN_INFO_GUANGDIAN
 LIGHT_9:
   lateInit: false
   item_group: slime_customizer_zhuangshi
@@ -5238,12 +3696,7 @@ LIGHT_9:
     material: LIGHT_9
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
-  recipe:
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_GUANGDIAN
-      amount: 1
+  recipe_type: HAIMAN_INFO_GUANGDIAN
 LIGHT_10:
   lateInit: false
   item_group: slime_customizer_zhuangshi
@@ -5252,12 +3705,7 @@ LIGHT_10:
     material: LIGHT_10
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
-  recipe:
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_GUANGDIAN
-      amount: 1
+  recipe_type: HAIMAN_INFO_GUANGDIAN
 LIGHT_11:
   lateInit: false
   item_group: slime_customizer_zhuangshi
@@ -5266,12 +3714,7 @@ LIGHT_11:
     material: LIGHT_11
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
-  recipe:
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_GUANGDIAN
-      amount: 1
+  recipe_type: HAIMAN_INFO_GUANGDIAN
 LIGHT_12:
   lateInit: false
   item_group: slime_customizer_zhuangshi
@@ -5280,12 +3723,7 @@ LIGHT_12:
     material: LIGHT_12
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
-  recipe:
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_GUANGDIAN
-      amount: 1
+  recipe_type: HAIMAN_INFO_GUANGDIAN
 LIGHT_13:
   lateInit: false
   item_group: slime_customizer_zhuangshi
@@ -5294,12 +3732,7 @@ LIGHT_13:
     material: LIGHT_13
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
-  recipe:
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_GUANGDIAN
-      amount: 1
+  recipe_type: HAIMAN_INFO_GUANGDIAN
 LIGHT_14:
   lateInit: false
   item_group: slime_customizer_zhuangshi
@@ -5308,19 +3741,14 @@ LIGHT_14:
     material: LIGHT_14
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
-  recipe:
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_GUANGDIAN
-      amount: 1
+  recipe_type: HAIMAN_INFO_GUANGDIAN
 MEITANZHONGZI:
   lateInit: false
   item_group: slime_customizer_zhuangshi
   item:
     name: '&b煤炭种子'
     lore:
-    - '&7放入矿物催生器可以收获矿物'
+      - '&7放入矿物催生器可以收获矿物'
     material_type: mc
     material: WHEAT_SEEDS
     amount: 1
@@ -5369,7 +3797,7 @@ TIEZHONGZI:
   item:
     name: '&b铁种子'
     lore:
-    - '&7放入矿物催生器可以收获矿物'
+      - '&7放入矿物催生器可以收获矿物'
     material_type: mc
     material: WHEAT_SEEDS
     amount: 1
@@ -5418,7 +3846,7 @@ JINZHONGZI:
   item:
     name: '&b金种子'
     lore:
-    - '&7放入矿物催生器可以收获矿物'
+      - '&7放入矿物催生器可以收获矿物'
     material_type: mc
     material: WHEAT_SEEDS
     amount: 1
@@ -5467,7 +3895,7 @@ LVBAOSHIZHONGZI:
   item:
     name: '&b绿宝石种子'
     lore:
-    - '&7放入矿物催生器可以收获矿物'
+      - '&7放入矿物催生器可以收获矿物'
     material_type: mc
     material: WHEAT_SEEDS
     amount: 1
@@ -5516,7 +3944,7 @@ ZUANSHIZHONGZI:
   item:
     name: '&b钻石种子'
     lore:
-    - '&7放入矿物催生器可以收获矿物'
+      - '&7放入矿物催生器可以收获矿物'
     material_type: mc
     material: WHEAT_SEEDS
     amount: 1
@@ -5565,7 +3993,7 @@ SHIYINGZHONGZI:
   item:
     name: '&b石英种子'
     lore:
-    - '&7放入矿物催生器可以收获矿物'
+      - '&7放入矿物催生器可以收获矿物'
     material_type: mc
     material: WHEAT_SEEDS
     amount: 1
@@ -5614,7 +4042,7 @@ QINGJINSHIZHONGZI:
   item:
     name: '&b青金石种子'
     lore:
-    - '&7放入矿物催生器可以收获矿物'
+      - '&7放入矿物催生器可以收获矿物'
     material_type: mc
     material: WHEAT_SEEDS
     amount: 1
@@ -5663,7 +4091,7 @@ HONGSHISHIZHONGZI:
   item:
     name: '&b红石种子'
     lore:
-    - '&7放入矿物催生器可以收获矿物'
+      - '&7放入矿物催生器可以收获矿物'
     material_type: mc
     material: WHEAT_SEEDS
     amount: 1
@@ -5712,7 +4140,7 @@ TONGZHONGZI:
   item:
     name: '&b铜种子'
     lore:
-    - '&7放入矿物催生器可以收获矿物'
+      - '&7放入矿物催生器可以收获矿物'
     material_type: mc
     material: WHEAT_SEEDS
     amount: 1
@@ -5853,7 +4281,7 @@ HAIMAN_ASIA_COUNTRY:
   item:
     name: '&c&l亚洲'
     lore:
-    - '&7亚洲地区'
+      - '&7亚洲地区'
     material_type: mc
     material: ORANGE_STAINED_GLASS_PANE
     amount: 1
@@ -8505,7 +6933,7 @@ HAIMAN_EUROPE_COUNTRY:
   item:
     name: '&c&l欧洲'
     lore:
-    - '&7欧洲地区'
+      - '&7欧洲地区'
     material_type: mc
     material: WHITE_STAINED_GLASS_PANE
     amount: 1
@@ -11301,7 +9729,7 @@ HAIMAN_AFRICA_COUNTRY:
   item:
     name: '&c&l非洲'
     lore:
-    - '&7非洲地区'
+      - '&7非洲地区'
     material_type: mc
     material: BLACK_STAINED_GLASS_PANE
     amount: 1
@@ -14289,7 +12717,7 @@ HAIMAN_AMERICA_COUNTRY:
   item:
     name: '&c&l美洲'
     lore:
-    - '&7美洲地区'
+      - '&7美洲地区'
     material_type: mc
     material: YELLOW_STAINED_GLASS_PANE
     amount: 1
@@ -16173,7 +14601,7 @@ HAIMAN_OCEANIA_COUNTRY:
   item:
     name: '&c&l大洋洲'
     lore:
-    - '&7大洋洲地区'
+      - '&7大洋洲地区'
     material_type: mc
     material: GREEN_STAINED_GLASS_PANE
     amount: 1
@@ -17001,7 +15429,7 @@ HAIMAN_ANTARCTICA_COUNTRY:
   item:
     name: '&c&l南极洲'
     lore:
-    - '&7南极洲地区'
+      - '&7南极洲地区'
     material_type: mc
     material: BLUE_STAINED_GLASS_PANE
     amount: 1
@@ -17245,9 +15673,9 @@ VR_INFO:
   item:
     name: '&b&l1.RV-Pre1版本提示'
     lore:
-    - '&7请在启动器中下载愚人节版本：1.RV-Pre1'
-    - '&7下载完成后启动游戏并登陆服务器'
-    - '&7即可使用本分类中物品'
+      - '&7请在启动器中下载愚人节版本：1.RV-Pre1'
+      - '&7下载完成后启动游戏并登陆服务器'
+      - '&7即可使用本分类中物品'
     material_type: mc
     material: PAPER
     amount: 1
@@ -17399,12 +15827,7 @@ BOOK_1:
     material: BOOK_1
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
-  recipe:
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_WRITTEN_BOOK_CHANGER
-      amount: 1
+  recipe_type: HAIMAN_INFO_WRITTEN_BOOK_CHANGER
 BOOK_2:
   lateInit: false
   item_group: slime_customizer_zhuangshi
@@ -17413,12 +15836,7 @@ BOOK_2:
     material: BOOK_2
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
-  recipe:
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_WRITTEN_BOOK_CHANGER
-      amount: 1
+  recipe_type: HAIMAN_INFO_WRITTEN_BOOK_CHANGER
 BOOK_3:
   lateInit: false
   item_group: slime_customizer_zhuangshi
@@ -17427,12 +15845,7 @@ BOOK_3:
     material: BOOK_3
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
-  recipe:
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_WRITTEN_BOOK_CHANGER
-      amount: 1
+  recipe_type: HAIMAN_INFO_WRITTEN_BOOK_CHANGER
 BOOK_4:
   lateInit: false
   item_group: slime_customizer_zhuangshi
@@ -17441,12 +15854,7 @@ BOOK_4:
     material: BOOK_4
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
-  recipe:
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_WRITTEN_BOOK_CHANGER
-      amount: 1
+  recipe_type: HAIMAN_INFO_WRITTEN_BOOK_CHANGER
 HAIMAN_COFFEE:
   lateInit: false
   item_group: slime_customizer_zhuangshi
@@ -17455,19 +15863,14 @@ HAIMAN_COFFEE:
     material: COFFEE
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
-  recipe:
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_COFFEE_MACHINE
-      amount: 1
+  recipe_type: HAIMAN_INFO_COFFEE_MACHINE
 HM_SHENQUAN_HEXIN:
   lateInit: false
   item_group: slime_customizer_material
   item:
     name: '&e&l神权核心'
     lore:
-    - '&7由各种神权方块拼接而成'
+      - '&7由各种神权方块拼接而成'
     material_type: skull_hash
     material: 5b10ed94080a07546a245ec837cfc5814c7658c7ef337be035a11b2e1e03ba16
     amount: 1
@@ -17516,7 +15919,7 @@ HAIMAN_INGOT:
   item:
     name: '&b&l海曼锭'
     lore:
-    - '&7一个栩栩如生的...苦力怕？'
+      - '&7一个栩栩如生的...苦力怕？'
     material_type: skull_hash
     material: 12208e6d30301bb70bf3043ac877b8bddb1590cff752a93ceae7c9d24efd67c9
     amount: 1
@@ -17565,7 +15968,7 @@ TIANXUAN_MADA:
   item:
     name: '&a&l天璇马达'
     lore:
-    - '&7由多种马达拆卸后组装而成'
+      - '&7由多种马达拆卸后组装而成'
     material_type: skull_hash
     material: f6cbd10b609a1ec82be786367e07093b1062a8d49d195d46a0ed8ea70c7793f4
     amount: 1
@@ -17614,7 +16017,7 @@ HM_HONGMENG_XINPIAN:
   item:
     name: '&c&l鸿蒙芯片'
     lore:
-    - '&7用于制作精密机器'
+      - '&7用于制作精密机器'
     material_type: skull_hash
     material: 33f2b23ba182a67ed9519dc589cc0631df7155f74fbc648a5ace901dbcadbd
     amount: 1
@@ -17663,7 +16066,7 @@ HM_HJZJ:
   item:
     name: '&b&l环境组件'
     lore:
-    - '&7由各种环境符文组成'
+      - '&7由各种环境符文组成'
     material_type: skull_hash
     material: feddaf8a6b61aaa788eecb36d9df0ecea623839a6d3643127402053dbc4a4f08
     amount: 1
@@ -17712,7 +16115,7 @@ HM_YYZJ:
   item:
     name: '&e&l音乐组件'
     lore:
-    - '&7由各种唱片组成'
+      - '&7由各种唱片组成'
     material_type: skull_hash
     material: 4c867a5723d2e0f24a7dc4a9c767a4658d12f9075d815f51a0e7f2ea75bde434
     amount: 1
@@ -17761,7 +16164,7 @@ HM_SWZJ:
   item:
     name: '&a&l生物组件'
     lore:
-    - '&7由各种生物掉落物组成'
+      - '&7由各种生物掉落物组成'
     material_type: skull_hash
     material: 647e2e5d55b6d04943519bed2557c6329e33b60b909dee8923cd88b115210
     amount: 1
@@ -17810,7 +16213,7 @@ HM_ZDZJ:
   item:
     name: '&4&l战斗组件'
     lore:
-    - '&7由各种装备组成'
+      - '&7由各种装备组成'
     material_type: skull_hash
     material: c928c4bd94ab1b6d93d100398586e4a6c35a7d7db9414dfdfb2d859ef55c8d64
     amount: 1
@@ -17859,7 +16262,7 @@ HM_FKZJ:
   item:
     name: '&d&l方块组件'
     lore:
-    - '&7由各种方块组成'
+      - '&7由各种方块组成'
     material_type: skull_hash
     material: 3cc787d2e1bd9b8f275f20f8f69ec1d1f08cffb670fe3ad8d94b9d010deb0c2a
     amount: 1
@@ -17908,7 +16311,7 @@ HM_HSZJ:
   item:
     name: '&4&l红石组件'
     lore:
-    - '&7由各种红石元件组成'
+      - '&7由各种红石元件组成'
     material_type: skull_hash
     material: 51bc0d443543cc18306b410ff7ac2e063044092465e240bc75de424a3989bb87
     amount: 1
@@ -17957,7 +16360,7 @@ HM_YSZJ:
   item:
     name: '&6&l运输组件'
     lore:
-    - '&7由运输工具组成'
+      - '&7由运输工具组成'
     material_type: skull_hash
     material: fe51ed1977be1cfb56929e81d272acb86405de528f7a6a242ff424ad6fef4ef1
     amount: 1
@@ -18006,7 +16409,7 @@ HM_ZWZJ:
   item:
     name: '&a&l植物组件'
     lore:
-    - '&7由各种植物组成'
+      - '&7由各种植物组成'
     material_type: skull_hash
     material: c3ea86015b7416aacf1b300db5fbdcd59f128a800f9f9c44be62c11921579811
     amount: 1
@@ -18055,7 +16458,7 @@ HM_DDXP:
   item:
     name: '&5&lMinecraft迭代芯片'
     lore:
-    - '&7用于更迭部分机器的版本'
+      - '&7用于更迭部分机器的版本'
     material_type: skull_hash
     material: 946120499b324639cd9a17799ea1dfff373e79afe1f0d8b5328cf47896c4775
     amount: 1
@@ -18104,7 +16507,7 @@ HM_HUOQI:
   item:
     name: '&f&l空火漆'
     lore:
-    - '&7用于印刷其它火漆'
+      - '&7用于印刷其它火漆'
     material_type: mc
     material: WHITE_DYE
     amount: 1
@@ -18153,7 +16556,7 @@ HM_XIXUEHUOQI:
   item:
     name: '&6&l吸血火漆'
     lore:
-    - '&7用于印刷吸血鬼之刀'
+      - '&7用于印刷吸血鬼之刀'
     material_type: skull_hash
     material: 52068ae754078e4dd2a008ee239b004afa9085a18c3a706ef919831414116b5e
     amount: 1
@@ -18202,7 +16605,7 @@ HM_CHUJUEHUOQI:
   item:
     name: '&6&l处决火漆'
     lore:
-    - '&7用于印刷处决之剑'
+      - '&7用于印刷处决之剑'
     material_type: skull_hash
     material: d6cc6b83763a67fcada1ea184c2d1752ad240746c6be258a73983d8b657f4bb5
     amount: 1
@@ -18251,7 +16654,7 @@ HM_BINGFENGHUOQI:
   item:
     name: '&6&l冰封火漆'
     lore:
-    - '&7用于印刷冰封之弓'
+      - '&7用于印刷冰封之弓'
     material_type: skull_hash
     material: 5da9cb6a91996face887007eb7c1c8e0dd4cefbdedf81ef46865377a3d9f2fcd
     amount: 1
@@ -18300,7 +16703,7 @@ HM_BAOZHAHUOQI:
   item:
     name: '&6&l爆炸火漆'
     lore:
-    - '&7用于印刷爆炸类武器/工具'
+      - '&7用于印刷爆炸类武器/工具'
     material_type: skull_hash
     material: d6f989a7341ba82eb01ccc1e3ba44fcbd49dde1d47ec96d9f4a8f209dd665243
     amount: 1
@@ -18349,7 +16752,7 @@ HM_DIZHENHUOQI:
   item:
     name: '&6&l地震火漆'
     lore:
-    - '&7用于印刷地震斧'
+      - '&7用于印刷地震斧'
     material_type: skull_hash
     material: 616cbae55037be6998a1a536886a4e3dab30050a5f2bf0dfaaa6a863672290da
     amount: 1
@@ -18398,7 +16801,7 @@ HM_NAINAIHUOQI:
   item:
     name: '&6&l奶奶火漆'
     lore:
-    - '&7用于印刷奶奶的拐杖'
+      - '&7用于印刷奶奶的拐杖'
     material_type: skull_hash
     material: dbc2b22444eb38bd29cbeecafa33b936f92ad1e8637bb11f84f868bf3d68a4
     amount: 1
@@ -18447,7 +16850,7 @@ HM_YEYEHUOQI:
   item:
     name: '&6&l爷爷火漆'
     lore:
-    - '&7用于印刷爷爷的拐杖'
+      - '&7用于印刷爷爷的拐杖'
     material_type: skull_hash
     material: 7bc972f7badbe931072e5c351e22ecb6e23a8c575e98c35fc8f4fbe3eab71c2c
     amount: 1
@@ -18496,7 +16899,7 @@ HM_RONGLUHUOQI:
   item:
     name: '&6&l熔炉火漆'
     lore:
-    - '&7用于印刷熔炉镐'
+      - '&7用于印刷熔炉镐'
     material_type: skull_hash
     material: d17b8b43f8c4b5cfeb919c9f8fe93f26ceb6d2b133c2ab1eb339bd6621fd309c
     amount: 1
@@ -18545,7 +16948,7 @@ HM_FAMUHUOQI:
   item:
     name: '&6&l伐木火漆'
     lore:
-    - '&7用于印刷伐木斧'
+      - '&7用于印刷伐木斧'
     material_type: skull_hash
     material: ee9bf657629852de527196960f5fbe401ae310f200c3c782115eab1a00ce2266
     amount: 1
@@ -18594,7 +16997,7 @@ HM_SHUAGUAILONGHUOQI:
   item:
     name: '&6&l刷怪笼火漆'
     lore:
-    - '&7用于印刷刷怪笼之镐'
+      - '&7用于印刷刷怪笼之镐'
     material_type: skull_hash
     material: db6bd9727abb55d5415265789d4f2984781a343c68dcaf57f554a5e9aa1cd
     amount: 1
@@ -18643,7 +17046,7 @@ HM_XUNKUANGHUOQI:
   item:
     name: '&6&l寻矿火漆'
     lore:
-    - '&7用于印刷寻矿镐'
+      - '&7用于印刷寻矿镐'
     material_type: skull_hash
     material: 686d721641d423e213aff0a61eb87217d30813cc31412752e3eb0864d6198209
     amount: 1
@@ -18692,7 +17095,7 @@ HM_KUANGMAIHUOQI:
   item:
     name: '&6&l矿脉火漆'
     lore:
-    - '&7用于印刷矿脉镐'
+      - '&7用于印刷矿脉镐'
     material_type: skull_hash
     material: 4e129bcdd718172a8e9b454a30a2d37be49ed5244576043ac0e19084a5b1ca1
     amount: 1
@@ -18741,7 +17144,7 @@ HM_PANYANHUOQI:
   item:
     name: '&6&l攀岩火漆'
     lore:
-    - '&7用于印刷攀岩镐'
+      - '&7用于印刷攀岩镐'
     material_type: skull_hash
     material: 2a643c5cca38d324bf81488db7e53f7785818cbfe20e9f732ae01fb2dac75ae6
     amount: 1
@@ -18790,7 +17193,7 @@ HM_YESHIHUOQI:
   item:
     name: '&6&l夜视火漆'
     lore:
-    - '&7用于印刷夜视眼镜'
+      - '&7用于印刷夜视眼镜'
     material_type: skull_hash
     material: ce9d49dd09ecee2a4996965514d6d301bf12870c688acb5999b6658e1dfdff85
     amount: 1
@@ -18839,7 +17242,7 @@ HM_HUANJIANGHUOQI:
   item:
     name: '&6&l缓降火漆'
     lore:
-    - '&7用于印刷降落伞'
+      - '&7用于印刷降落伞'
     material_type: skull_hash
     material: 50c13b9a7049d191508ba6758c09a91d923c4b9972052c35602af54f0c4bb55a
     amount: 1
@@ -18888,7 +17291,7 @@ HM_NONGFUHUOQI:
   item:
     name: '&6&l农夫火漆'
     lore:
-    - '&7用于印刷农夫的靴子'
+      - '&7用于印刷农夫的靴子'
     material_type: skull_hash
     material: 925a32560831c295b00527926255e608a039776f3523b92edf788149aae67d6a
     amount: 1
@@ -18937,7 +17340,7 @@ HM_QIAOCHIHUOQI:
   item:
     name: '&6&l鞘翅火漆'
     lore:
-    - '&7用于印刷鞘翅帽'
+      - '&7用于印刷鞘翅帽'
     material_type: skull_hash
     material: 850bd5a82c738ae78d0ae3f57b4071c0df40534876301640dab14a70930bbe65
     amount: 1
@@ -18986,7 +17389,7 @@ HM_JIANTAZHEHUOQI:
   item:
     name: '&6&l践踏者火漆'
     lore:
-    - '&7用于印刷践踏者之靴'
+      - '&7用于印刷践踏者之靴'
     material_type: skull_hash
     material: c4eb297a2fd00b79c5e8fdd649bbb2b2acc6a0f6c8858739b86875cd4b4444a7
     amount: 1
@@ -19035,7 +17438,7 @@ HM_MOYINGHUOQI:
   item:
     name: '&6&l末影火漆'
     lore:
-    - '&7用于印刷末影套装和末影背包'
+      - '&7用于印刷末影套装和末影背包'
     material_type: skull_hash
     material: 20baf2277cd54eb4d76e60a7b79f27adde00e0d094acaa0d874b52288a1af579
     amount: 1
@@ -19084,7 +17487,7 @@ HM_SHILAIMUHUOQI:
   item:
     name: '&6&l史莱姆火漆'
     lore:
-    - '&7用于印刷史莱姆套装'
+      - '&7用于印刷史莱姆套装'
     material_type: skull_hash
     material: 5d5b94804e64851f4e9c48ced3c1975df35b958d570df7a9fb94bf311437c91b
     amount: 1
@@ -19133,7 +17536,7 @@ HM_YINGSHIHUOQI:
   item:
     name: '&6&l萤石火漆'
     lore:
-    - '&7用于印刷萤石套装'
+      - '&7用于印刷萤石套装'
     material_type: skull_hash
     material: c3076eea20b94c8c9dd8f6d459b7930f790d43c83664fa871047d91f340d4df6
     amount: 1
@@ -19182,7 +17585,7 @@ HM_CAIHONGHUOQI:
   item:
     name: '&6&l彩虹火漆'
     lore:
-    - '&7用于印刷彩虹套装'
+      - '&7用于印刷彩虹套装'
     material_type: skull_hash
     material: 9f7c54ff7862116e65a1436620b91af58b52ab17152a1837180f3458032f5702
     amount: 1
@@ -19231,7 +17634,7 @@ HM_MIFENGHUOQI:
   item:
     name: '&6&l蜜蜂火漆'
     lore:
-    - '&7用于印刷蜜蜂套装'
+      - '&7用于印刷蜜蜂套装'
     material_type: skull_hash
     material: a1235c3dececec89f37f25abbefa227ec3a4fe73e03be9361ed473301b4e0d7b
     amount: 1
@@ -19280,7 +17683,7 @@ HM_TAIYANGNENGHUOQI:
   item:
     name: '&6&l太阳能火漆'
     lore:
-    - '&7用于印刷太阳能头盔'
+      - '&7用于印刷太阳能头盔'
     material_type: skull_hash
     material: 35dd37f729fc88133e314a552204c0fa2c0168428b353f957bf15ff24b7707e0
     amount: 1
@@ -19329,7 +17732,7 @@ HM_FANGHUAHUOQI:
   item:
     name: '&6&l防化火漆'
     lore:
-    - '&7用于印刷防化套装'
+      - '&7用于印刷防化套装'
     material_type: skull_hash
     material: 2ca29266eb6951885950895921dd681a47be73caf066ef947a23a3742c228237
     amount: 1
@@ -19378,7 +17781,7 @@ HM_XIANRENZHANGHUOQI:
   item:
     name: '&6&l仙人掌火漆'
     lore:
-    - '&7用于印刷仙人掌套装'
+      - '&7用于印刷仙人掌套装'
     material_type: skull_hash
     material: 7037ebbfe225b80077fe3f16deb63ebff723b89d69f155883581d257a45508d6
     amount: 1
@@ -19427,8 +17830,8 @@ HM_SUOLIANHUOQI:
   item:
     name: '&6&l锁链火漆'
     lore:
-    - '&7用于印刷锁链套装'
-    - '&7锁链套装的原胚为皮革套装'
+      - '&7用于印刷锁链套装'
+      - '&7锁链套装的原胚为皮革套装'
     material_type: skull_hash
     material: 6803d569ac46fbb5f4d6fc3b64539fda0848e7376f729150e5949cbbcee67870
     amount: 1
@@ -19477,7 +17880,7 @@ HM_LHBDHUOQI:
   item:
     name: '&6&l灵魂绑定火漆'
     lore:
-    - '&7用于印刷灵魂绑定套装'
+      - '&7用于印刷灵魂绑定套装'
     material_type: skull_hash
     material: 3da33acb36925bb3d1f669b02f9233327dec2c28f63a4b6d667c70edcf90aee4
     amount: 1
@@ -19526,8 +17929,8 @@ JISHIQI_DUAN:
   item:
     name: '&e&l短轴计时器'
     lore:
-    - '&7可放在牌桌的非消耗型物品槽内计时'
-    - '&7时长：5 粘液刻'
+      - '&7可放在牌桌的非消耗型物品槽内计时'
+      - '&7时长：5 粘液刻'
     material_type: skull_hash
     material: 78472a2dcc239b4a483ac44c1dbf8fdba0fca1d253eb643fa0bd93af83a373
     amount: 1
@@ -19576,8 +17979,8 @@ JISHIQI_CHANG:
   item:
     name: '&e&l长轴计时器'
     lore:
-    - '&7可放在牌桌的非消耗型物品槽内计时'
-    - '&7时长：15 粘液刻'
+      - '&7可放在牌桌的非消耗型物品槽内计时'
+      - '&7时长：15 粘液刻'
     material_type: skull_hash
     material: 85fa0a3a2d62d7d1171d48b3ae8fcb551f6faccc70cee40f44c767c3da7b785f
     amount: 1
@@ -19626,7 +18029,7 @@ TISHI_SHIJIAN:
   item:
     name: '&e&l提示'
     lore:
-    - '&7嘀嗒！时间到！'
+      - '&7嘀嗒！时间到！'
     material_type: mc
     material: PAPER
     amount: 1
@@ -19776,7 +18179,7 @@ CHUANGSHI_YIN:
   item:
     name: '&4&l创世之音'
     lore:
-    - '&7创世由此而来'
+      - '&7创世由此而来'
     material_type: skull_hash
     material: f22e40b4bfbcc0433044d86d67685f0567025904271d0a74996afbe3f9be2c0f
     amount: 1
@@ -19805,43 +18208,35 @@ HT_MODULE_1:
   item:
     name: '&5&l创世高温模块'
     lore:
-    - '&7它可以将温度升至一亿摄氏度以上'
+      - '&7它可以将温度升至一亿摄氏度以上'
     material_type: skull_hash
     material: f25a8dfe753c9c9251f0b0f6d94e9c8ffd42c1579550bf922d1862ff986c4d5
     amount: 1
   placeable: false
-  recipe_type: 'NULL'
+  recipe_type: HAIMAN_INFO_FENZI_5
   recipe:
     1:
       material_type: slimefun
       material: INFINITE_PANEL
       amount: 12
-    3:
+    2:
       material_type: slimefun
       material: CHUANGSHI_YIN
       amount: 6
-    5:
-      material_type: slimefun
-      material: HAIMAN_INFO_FENZI_5
-      amount: 1
 JUBIAN_MOKUAI:
   lateInit: false
   item_group: slime_customizer_material
   item:
     name: '&4&l聚变高温模块'
     lore:
-    - '&7可将温度再提升一个档次'
+      - '&7可将温度再提升一个档次'
     material_type: skull_hash
     material: 240cc89db3fe8eb643bcd58fc2c58057e33d8a2b78172664f56ddc72635dc43b
     amount: 1
   placeable: true
-  recipe_type: 'NULL'
+  recipe_type: HAIMAN_INFO_HEIDONG
   recipe:
-    2:
-      material_type: slimefun
-      material: HT_MODULE_1
-      amount: 1
     5:
       material_type: slimefun
-      material: HAIMAN_INFO_HEIDONG
+      material: HT_MODULE_1
       amount: 1

--- a/HaimanTech2-rsc/recipe_machines.yml
+++ b/HaimanTech2-rsc/recipe_machines.yml
@@ -1065,7 +1065,7 @@ MOLECULAR_RECOMBINATION_INSTRUMENT_II:
       output:
         1:
           material_type: mc
-          material: TURTLE_SCUTE
+          material: SCUTE
           amount: 1
     '7':
       seconds: 55
@@ -1830,7 +1830,7 @@ MOLECULAR_RECOMBINATION_INSTRUMENT_III:
       output:
         1:
           material_type: mc
-          material: TURTLE_SCUTE
+          material: SCUTE
           amount: 1
     '7':
       seconds: 28
@@ -2714,7 +2714,7 @@ MOLECULAR_RECOMBINATION_INSTRUMENT_IV:
       output:
         1:
           material_type: mc
-          material: TURTLE_SCUTE
+          material: SCUTE
           amount: 5
     '7':
       seconds: 1
@@ -3670,7 +3670,7 @@ MOLECULAR_RECOMBINATION_INSTRUMENT_V:
       output:
         1:
           material_type: mc
-          material: TURTLE_SCUTE
+          material: SCUTE
           amount: 32
     '7':
       seconds: 1
@@ -5545,12 +5545,12 @@ HAIMAN_PLANT_MACHINE:
       input:
         1:
           material_type: mc
-          material: SHORT_GRASS
+          material: GRASS
           amount: 0
       output:
         1:
           material_type: mc
-          material: SHORT_GRASS
+          material: GRASS
           amount: 2
     '2':
       seconds: 2
@@ -6358,7 +6358,7 @@ HAIMAN_PLANT_MAKER:
       input:
         1:
           material_type: mc
-          material: SHORT_GRASS
+          material: GRASS
           amount: 1
       output:
         1:
@@ -6699,7 +6699,7 @@ HAIMAN_PLANT_MAKER:
       output:
         1:
           material_type: mc
-          material: SHORT_GRASS
+          material: GRASS
           amount: 1
   input: [0, 1, 2, 9, 10, 11, 13, 18, 19, 20, 27, 28, 29, 30, 36, 37, 38, 39, 45, 46, 47, 48]
   output: [6, 7, 8, 15, 16, 17, 24, 25, 26, 32, 33, 34, 35, 41, 42, 43, 44, 50, 51, 52, 53]
@@ -9666,7 +9666,7 @@ GRASS_WOOD_CHANGER:
       amount: 1
     4:
       material_type: mc
-      material: SHORT_GRASS
+      material: GRASS
       amount: 1
     5:
       material_type: slimefun
@@ -9674,7 +9674,7 @@ GRASS_WOOD_CHANGER:
       amount: 1
     6:
       material_type: mc
-      material: SHORT_GRASS
+      material: GRASS
       amount: 1
     7:
       material_type: slimefun
@@ -9708,7 +9708,7 @@ GRASS_WOOD_CHANGER:
       input:
         1:
           material_type: mc
-          material: SHORT_GRASS
+          material: GRASS
           amount: 1
       output:
         1:
@@ -39909,7 +39909,7 @@ HAIMAN_CAIBAN:
           amount: 3
         2:
           material_type: mc
-          material: SHORT_GRASS
+          material: GRASS
           amount: 1
     '7':
       seconds: 1

--- a/HaimanTech2-rsc/recipe_machines.yml
+++ b/HaimanTech2-rsc/recipe_machines.yml
@@ -4,10 +4,10 @@ COMPRESSION_BLOCK_MACHINE:
   item:
     name: '&b&l压块机'
     lore:
-    - '&7可以将铁锭/24k金锭/煤炭压成块'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 160 J 可存储'
-    - '&8⇨ &e⚡&7 32 J/s'
+      - '&7可以将铁锭/24k金锭/煤炭压成块'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 160 J 可存储'
+      - '&8⇨ &e⚡&7 32 J/s'
     material_type: skull_hash
     material: 2986794521869e8327ef81dbc35c9856bc4051df9888d81eab212442b176a82f
   speed: 1
@@ -384,11 +384,11 @@ HAIMAN_RESISTANCE:
   item:
     name: '&4&l海曼牌电阻'
     lore:
-    - '&7是否觉得你的电太多了？'
-    - '&7通入红石就可以消耗你大量的费电？'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 2147483647 J 可存储'
-    - '&8⇨ &e⚡&7 4294967294 J/s'
+      - '&7是否觉得你的电太多了？'
+      - '&7通入红石就可以消耗你大量的费电？'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 2147483647 J 可存储'
+      - '&8⇨ &e⚡&7 4294967294 J/s'
     material_type: skull_hash
     material: dcd7a00de13ec9f3c59d7cf902d980f5d29002c0dad754acbda0f6c2b698fd05
   speed: 1
@@ -453,10 +453,10 @@ NUCLEAR_DECAY_MACHINE:
   item:
     name: '&a&l核衰变机'
     lore:
-    - '&7可以快速的进行核衰变'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 10000 J 可存储'
-    - '&8⇨ &e⚡&7 1200 J/s'
+      - '&7可以快速的进行核衰变'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 10000 J 可存储'
+      - '&8⇨ &e⚡&7 1200 J/s'
     material_type: skull_hash
     material: ca9cb0457d5015dfbd3e252d76707127591063a0b2febaf8c644acada90bd4d0
   speed: 1
@@ -537,10 +537,10 @@ MILK_HONEY_MACHINE:
   item:
     name: '&4&l采蜜挤奶一体机'
     lore:
-    - '&7自动生产牛奶和蜂蜜'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1000 J 可存储'
-    - '&8⇨ &e⚡&7 100 J/s'
+      - '&7自动生产牛奶和蜂蜜'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1000 J 可存储'
+      - '&8⇨ &e⚡&7 100 J/s'
     material_type: skull_hash
     material: 6375a78d0f6c7c16b77399ab0d5f41c57cf328de94552067db20df87603363b1
   speed: 1
@@ -617,10 +617,10 @@ ANCIENT_DEBRIS_MACHINE:
   item:
     name: '&c&l残骸生产机'
     lore:
-    - '&7用来生产远古的残骸'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 20000 J 可存储'
-    - '&8⇨ &e⚡&7 7600 J/s'
+      - '&7用来生产远古的残骸'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 20000 J 可存储'
+      - '&8⇨ &e⚡&7 7600 J/s'
     material_type: skull_hash
     material: cd4a7fce6f888e8042d634c7973b3cbc7e9320f1744608e6c5cdd5f4ef9ca393
   speed: 1
@@ -685,11 +685,11 @@ MOLECULAR_RECOMBINATION_INSTRUMENT_I:
   item:
     name: '&b&l分子重组仪 &7- &aI'
     lore:
-    - '&8用来重组最基本的物品'
-    - '&7输入材料少但是重组时间长'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 36000 J 可存储'
-    - '&8⇨ &e⚡&7 3600 J/s'
+      - '&8用来重组最基本的物品'
+      - '&7输入材料少但是重组时间长'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 36000 J 可存储'
+      - '&8⇨ &e⚡&7 3600 J/s'
     material_type: skull_hash
     material: eb308694c5b01e815d498535f4c3db5827b4cc45f12a33717ad0ca9fe24509c0
   speed: 1
@@ -946,11 +946,11 @@ MOLECULAR_RECOMBINATION_INSTRUMENT_II:
   item:
     name: '&b&l分子重组仪 &7- &eII'
     lore:
-    - '&8用来重组较为高级的物品'
-    - '&7输入材料多但是重组时间较短'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 70000 J 可存储'
-    - '&8⇨ &e⚡&7 14000 J/s'
+      - '&8用来重组较为高级的物品'
+      - '&7输入材料多但是重组时间较短'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 70000 J 可存储'
+      - '&8⇨ &e⚡&7 14000 J/s'
     material_type: skull_hash
     material: a44c5ce2eb643f8671c667e8802c9317ad8cc6af680d4ef671d8c0c63277900a
   speed: 1
@@ -1065,7 +1065,7 @@ MOLECULAR_RECOMBINATION_INSTRUMENT_II:
       output:
         1:
           material_type: mc
-          material: SCUTE
+          material: TURTLE_SCUTE
           amount: 1
     '7':
       seconds: 55
@@ -1327,11 +1327,11 @@ VERSIONED_MOLECULAR_RECOMBINATION_INSTRUMENT_II:
   item:
     name: '&b&l分子重组仪 &7- &eII'
     lore:
-    - '&8用来重组较为高级的物品'
-    - '&7输入材料多但是重组时间较短'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 70000 J 可存储'
-    - '&8⇨ &e⚡&7 14000 J/s'
+      - '&8用来重组较为高级的物品'
+      - '&7输入材料多但是重组时间较短'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 70000 J 可存储'
+      - '&8⇨ &e⚡&7 14000 J/s'
     material_type: skull_hash
     material: a44c5ce2eb643f8671c667e8802c9317ad8cc6af680d4ef671d8c0c63277900a
   speed: 1
@@ -1703,7 +1703,7 @@ VERSIONED_MOLECULAR_RECOMBINATION_INSTRUMENT_II:
   id_alias: MOLECULAR_RECOMBINATION_INSTRUMENT_II
   register:
     conditions:
-    - version >= 1.20.5
+      - version >= 1.20.5
   input: [0, 1, 2, 9, 10, 11, 13, 18, 19, 20, 27, 28, 29, 30, 36, 37, 38, 39, 45, 46, 47, 48]
   output: [6, 7, 8, 15, 16, 17, 24, 25, 26, 32, 33, 34, 35, 41, 42, 43, 44, 50, 51, 52, 53]
 MOLECULAR_RECOMBINATION_INSTRUMENT_III:
@@ -1712,10 +1712,10 @@ MOLECULAR_RECOMBINATION_INSTRUMENT_III:
   item:
     name: '&b&l分子重组仪 &7- &6III'
     lore:
-    - '&8海曼的新型高科技'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 900000 J 可存储'
-    - '&8⇨ &e⚡&7 40000 J/s'
+      - '&8海曼的新型高科技'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 900000 J 可存储'
+      - '&8⇨ &e⚡&7 40000 J/s'
     material_type: skull_hash
     material: 5dff8dbbab15bfbb11e23b1f50b34ef548ad9832c0bd7f5a13791adad0057e1b
   speed: 1
@@ -1830,7 +1830,7 @@ MOLECULAR_RECOMBINATION_INSTRUMENT_III:
       output:
         1:
           material_type: mc
-          material: SCUTE
+          material: TURTLE_SCUTE
           amount: 1
     '7':
       seconds: 28
@@ -2152,10 +2152,10 @@ VERSIONED_MOLECULAR_RECOMBINATION_INSTRUMENT_III:
   item:
     name: '&b&l分子重组仪 &7- &6III'
     lore:
-    - '&8海曼的新型高科技'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 900000 J 可存储'
-    - '&8⇨ &e⚡&7 40000 J/s'
+      - '&8海曼的新型高科技'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 900000 J 可存储'
+      - '&8⇨ &e⚡&7 40000 J/s'
     material_type: skull_hash
     material: 5dff8dbbab15bfbb11e23b1f50b34ef548ad9832c0bd7f5a13791adad0057e1b
   speed: 1
@@ -2587,7 +2587,7 @@ VERSIONED_MOLECULAR_RECOMBINATION_INSTRUMENT_III:
   id_alias: MOLECULAR_RECOMBINATION_INSTRUMENT_III
   register:
     conditions:
-    - version >= 1.20.5
+      - version >= 1.20.5
   input: [0, 1, 2, 9, 10, 11, 13, 18, 19, 20, 27, 28, 29, 30, 36, 37, 38, 39, 45, 46, 47, 48]
   output: [6, 7, 8, 15, 16, 17, 24, 25, 26, 32, 33, 34, 35, 41, 42, 43, 44, 50, 51, 52, 53]
 MOLECULAR_RECOMBINATION_INSTRUMENT_IV:
@@ -2596,10 +2596,10 @@ MOLECULAR_RECOMBINATION_INSTRUMENT_IV:
   item:
     name: '&b&l分子重组仪 &7- &cIV'
     lore:
-    - '&8这...是4级重组仪？'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 930000 J 可存储'
-    - '&8⇨ &e⚡&7 60000 J/s'
+      - '&8这...是4级重组仪？'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 930000 J 可存储'
+      - '&8⇨ &e⚡&7 60000 J/s'
     material_type: skull_hash
     material: 57ccd36dc8f72adcb1f8c8e61ee82cd96ead140cf2a16a1366be9b5a8e3cc3fc
   speed: 1
@@ -2714,7 +2714,7 @@ MOLECULAR_RECOMBINATION_INSTRUMENT_IV:
       output:
         1:
           material_type: mc
-          material: SCUTE
+          material: TURTLE_SCUTE
           amount: 5
     '7':
       seconds: 1
@@ -3072,10 +3072,10 @@ VERSIONED_MOLECULAR_RECOMBINATION_INSTRUMENT_IV:
   item:
     name: '&b&l分子重组仪 &7- &cIV'
     lore:
-    - '&8这...是4级重组仪？'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 930000 J 可存储'
-    - '&8⇨ &e⚡&7 60000 J/s'
+      - '&8这...是4级重组仪？'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 930000 J 可存储'
+      - '&8⇨ &e⚡&7 60000 J/s'
     material_type: skull_hash
     material: 57ccd36dc8f72adcb1f8c8e61ee82cd96ead140cf2a16a1366be9b5a8e3cc3fc
   speed: 1
@@ -3543,7 +3543,7 @@ VERSIONED_MOLECULAR_RECOMBINATION_INSTRUMENT_IV:
   id_alias: MOLECULAR_RECOMBINATION_INSTRUMENT_IV
   register:
     conditions:
-    - version >= 1.20.5
+      - version >= 1.20.5
   input: [0, 1, 2, 9, 10, 11, 13, 18, 19, 20, 27, 28, 29, 30, 36, 37, 38, 39, 45, 46, 47, 48]
   output: [6, 7, 8, 15, 16, 17, 24, 25, 26, 32, 33, 34, 35, 41, 42, 43, 44, 50, 51, 52, 53]
 MOLECULAR_RECOMBINATION_INSTRUMENT_V:
@@ -3552,10 +3552,10 @@ MOLECULAR_RECOMBINATION_INSTRUMENT_V:
   item:
     name: '&b&l分子重组仪 &7- &4V'
     lore:
-    - '&8这难道就是最终目标吗？'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 950000 J 可存储'
-    - '&8⇨ &e⚡&7 80000 J/s'
+      - '&8这难道就是最终目标吗？'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 950000 J 可存储'
+      - '&8⇨ &e⚡&7 80000 J/s'
     material_type: skull_hash
     material: 30a35957fce2344aa8557ba6b36187ab415249934607bbbed2a053c3a86cafc0
   speed: 1
@@ -3670,7 +3670,7 @@ MOLECULAR_RECOMBINATION_INSTRUMENT_V:
       output:
         1:
           material_type: mc
-          material: SCUTE
+          material: TURTLE_SCUTE
           amount: 32
     '7':
       seconds: 1
@@ -4096,10 +4096,10 @@ VERSIONED_MOLECULAR_RECOMBINATION_INSTRUMENT_V:
   item:
     name: '&b&l分子重组仪 &7- &4V'
     lore:
-    - '&8这难道就是最终目标吗？'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 950000 J 可存储'
-    - '&8⇨ &e⚡&7 80000 J/s'
+      - '&8这难道就是最终目标吗？'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 950000 J 可存储'
+      - '&8⇨ &e⚡&7 80000 J/s'
     material_type: skull_hash
     material: 30a35957fce2344aa8557ba6b36187ab415249934607bbbed2a053c3a86cafc0
   speed: 1
@@ -4635,7 +4635,7 @@ VERSIONED_MOLECULAR_RECOMBINATION_INSTRUMENT_V:
   id_alias: MOLECULAR_RECOMBINATION_INSTRUMENT_V
   register:
     conditions:
-    - version >= 1.20.5
+      - version >= 1.20.5
   input: [0, 1, 2, 9, 10, 11, 13, 18, 19, 20, 27, 28, 29, 30, 36, 37, 38, 39, 45, 46, 47, 48]
   output: [6, 7, 8, 15, 16, 17, 24, 25, 26, 32, 33, 34, 35, 41, 42, 43, 44, 50, 51, 52, 53]
 MOLECULAR_RECOMBINATION_INSTRUMENT_32767:
@@ -4644,19 +4644,19 @@ MOLECULAR_RECOMBINATION_INSTRUMENT_32767:
   item:
     name: '&b&l分子重组仪 &7- &5xxxMMDCCLXVII'
     lore:
-    - '&8嗯？这是32767级的重组仪？'
-    - '&7在分子重组仪改装机中改装升级'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 114514 J 可存储'
-    - '&8⇨ &e⚡&7 65534 J/s'
+      - '&8嗯？这是32767级的重组仪？'
+      - '&7在分子重组仪改装机中改装升级'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 114514 J 可存储'
+      - '&8⇨ &e⚡&7 65534 J/s'
     material_type: skull_hash
     material: 6f89b150be9c4c5249f355f68ea0c4391300a9be1f260d750fc35a1817ad796e
   speed: 1
-  recipe_type: 'NULL'
+  recipe_type: HAIMAN_INFO_FENZI_GAIZHUANG
   recipe:
     5:
       material_type: slimefun
-      material: HAIMAN_INFO_FENZI_GAIZHUANG
+      material: MOLECULAR_RECOMBINATION_INSTRUMENT_I
       amount: 1
   capacity: 114514
   energyPerCraft: 32767
@@ -4717,10 +4717,10 @@ MOLECULAR_CHANGER:
   item:
     name: '&9&l分子重组仪改装机'
     lore:
-    - '&7对分子重组仪进行魔改'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 12000 J 可存储'
-    - '&8⇨ &e⚡&7 1200 J/s'
+      - '&7对分子重组仪进行魔改'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 12000 J 可存储'
+      - '&8⇨ &e⚡&7 1200 J/s'
     material_type: skull_hash
     material: 2afeefa29bfdb3202238a2c4b8dcb750506a30d122600f88725e5aa247335460
   speed: 1
@@ -4785,10 +4785,10 @@ COMMAND_BLOCK_DYE_MACHINE:
   item:
     name: '&6&l命令方块染色机'
     lore:
-    - '&7可以给命令方块染色的机器'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 2500 J 可存储'
-    - '&8⇨ &e⚡&7 900 J/s'
+      - '&7可以给命令方块染色的机器'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 2500 J 可存储'
+      - '&8⇨ &e⚡&7 900 J/s'
     material_type: skull_hash
     material: ed924489282abeb38aeacbf4c0eb3ad400d5257ffb3a605b87cf231c92fa2f4c
   speed: 1
@@ -4877,10 +4877,10 @@ COMMAND_BLOCK_DYE_MACHINE_2:
   item:
     name: '&c&l命令方块浸染机'
     lore:
-    - '&7更快的给命令方块染色的机器'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 6000 J 可存储'
-    - '&8⇨ &e⚡&7 3000 J/s'
+      - '&7更快的给命令方块染色的机器'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 6000 J 可存储'
+      - '&8⇨ &e⚡&7 3000 J/s'
     material_type: skull_hash
     material: 6d0f4061bfb767a7f922a6ca7176f7a9b20709bd0512696beb15ea6fa98ca55c
   speed: 1
@@ -4969,11 +4969,11 @@ HAIMAN_MUSHROOM_MACHINE:
   item:
     name: '&9&l菌落机'
     lore:
-    - '&7自动培育各类蘑菇'
-    - '&7须在输入槽内放入相应的蘑菇'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1000 J 可存储'
-    - '&8⇨ &e⚡&7 30 J/s'
+      - '&7自动培育各类蘑菇'
+      - '&7须在输入槽内放入相应的蘑菇'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1000 J 可存储'
+      - '&8⇨ &e⚡&7 30 J/s'
     material_type: skull_hash
     material: d0c3bdd04d05a7d5252b9063fe08b64d644e1e30f5c69171ec33b6f9aa41d967
   speed: 1
@@ -5146,11 +5146,11 @@ HAIMAN_FLOWER_MACHINE:
   item:
     name: '&6&l花匠机'
     lore:
-    - '&7自动培育各类花'
-    - '&7须在输入槽内放入相应的花'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1000 J 可存储'
-    - '&8⇨ &e⚡&7 30 J/s'
+      - '&7自动培育各类花'
+      - '&7须在输入槽内放入相应的花'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1000 J 可存储'
+      - '&8⇨ &e⚡&7 30 J/s'
     material_type: skull_hash
     material: 4b57a4c68d1d2c5de978ea6de4db91ef387ca6c37966bb8e7c8826f937e6c3
   speed: 1
@@ -5491,11 +5491,11 @@ HAIMAN_PLANT_MACHINE:
   item:
     name: '&a&l植物栽培机'
     lore:
-    - '&7自动培育杂类陆地/海洋/下界/末地植物'
-    - '&7须在输入槽内放入相应的植物'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1000 J 可存储'
-    - '&8⇨ &e⚡&7 30 J/s'
+      - '&7自动培育杂类陆地/海洋/下界/末地植物'
+      - '&7须在输入槽内放入相应的植物'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1000 J 可存储'
+      - '&8⇨ &e⚡&7 30 J/s'
     material_type: skull_hash
     material: 24af8d575f0a524ef66a21573e8a4a8ac7d640b00d98e2e9374e60470e7c86f0
   speed: 1
@@ -5545,12 +5545,12 @@ HAIMAN_PLANT_MACHINE:
       input:
         1:
           material_type: mc
-          material: GRASS
+          material: SHORT_GRASS
           amount: 0
       output:
         1:
           material_type: mc
-          material: GRASS
+          material: SHORT_GRASS
           amount: 2
     '2':
       seconds: 2
@@ -5896,11 +5896,11 @@ VERSIONED_HAIMAN_PLANT_MACHINE:
   item:
     name: '&a&l植物栽培机'
     lore:
-    - '&7自动培育杂类陆地/海洋/下界/末地植物'
-    - '&7须在输入槽内放入相应的植物'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1000 J 可存储'
-    - '&8⇨ &e⚡&7 30 J/s'
+      - '&7自动培育杂类陆地/海洋/下界/末地植物'
+      - '&7须在输入槽内放入相应的植物'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1000 J 可存储'
+      - '&8⇨ &e⚡&7 30 J/s'
     material_type: skull_hash
     material: 24af8d575f0a524ef66a21573e8a4a8ac7d640b00d98e2e9374e60470e7c86f0
   speed: 1
@@ -6296,7 +6296,7 @@ VERSIONED_HAIMAN_PLANT_MACHINE:
   id_alias: HAIMAN_PLANT_MACHINE
   register:
     conditions:
-    - version >= 1.20.3
+      - version >= 1.20.3
   input: [0, 1, 2, 9, 10, 11, 13, 18, 19, 20, 27, 28, 29, 30, 36, 37, 38, 39, 45, 46, 47, 48]
   output: [6, 7, 8, 15, 16, 17, 24, 25, 26, 32, 33, 34, 35, 41, 42, 43, 44, 50, 51, 52, 53]
 HAIMAN_PLANT_MAKER:
@@ -6305,10 +6305,10 @@ HAIMAN_PLANT_MAKER:
   item:
     name: '&a&l植物转换机'
     lore:
-    - '&7转换各类陆地/海洋/下界/末地植物'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1500 J 可存储'
-    - '&8⇨ &e⚡&7 30 J/s'
+      - '&7转换各类陆地/海洋/下界/末地植物'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1500 J 可存储'
+      - '&8⇨ &e⚡&7 30 J/s'
     material_type: skull_hash
     material: 847b95f1240e5a4d025858b2f2bd825a73d0792136a157ea925e56f9ee31851b
   speed: 1
@@ -6358,7 +6358,7 @@ HAIMAN_PLANT_MAKER:
       input:
         1:
           material_type: mc
-          material: GRASS
+          material: SHORT_GRASS
           amount: 1
       output:
         1:
@@ -6699,7 +6699,7 @@ HAIMAN_PLANT_MAKER:
       output:
         1:
           material_type: mc
-          material: GRASS
+          material: SHORT_GRASS
           amount: 1
   input: [0, 1, 2, 9, 10, 11, 13, 18, 19, 20, 27, 28, 29, 30, 36, 37, 38, 39, 45, 46, 47, 48]
   output: [6, 7, 8, 15, 16, 17, 24, 25, 26, 32, 33, 34, 35, 41, 42, 43, 44, 50, 51, 52, 53]
@@ -6709,10 +6709,10 @@ VERSIONED_HAIMAN_PLANT_MAKER:
   item:
     name: '&a&l植物转换机'
     lore:
-    - '&7转换各类陆地/海洋/下界/末地植物'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1500 J 可存储'
-    - '&8⇨ &e⚡&7 30 J/s'
+      - '&7转换各类陆地/海洋/下界/末地植物'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1500 J 可存储'
+      - '&8⇨ &e⚡&7 30 J/s'
     material_type: skull_hash
     material: 847b95f1240e5a4d025858b2f2bd825a73d0792136a157ea925e56f9ee31851b
   speed: 1
@@ -7108,7 +7108,7 @@ VERSIONED_HAIMAN_PLANT_MAKER:
   id_alias: HAIMAN_PLANT_MAKER
   register:
     conditions:
-    - version >= 1.20.3
+      - version >= 1.20.3
   input: [0, 1, 2, 9, 10, 11, 13, 18, 19, 20, 27, 28, 29, 30, 36, 37, 38, 39, 45, 46, 47, 48]
   output: [6, 7, 8, 15, 16, 17, 24, 25, 26, 32, 33, 34, 35, 41, 42, 43, 44, 50, 51, 52, 53]
 HAIMAN_FLOWER_MAKER:
@@ -7117,10 +7117,10 @@ HAIMAN_FLOWER_MAKER:
   item:
     name: '&6&l花卉转换机'
     lore:
-    - '&7转换各类花'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1000 J 可存储'
-    - '&8⇨ &e⚡&7 30 J/s'
+      - '&7转换各类花'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1000 J 可存储'
+      - '&8⇨ &e⚡&7 30 J/s'
     material_type: skull_hash
     material: dc6f38a37f71328c34df3ff9bd819d2e549f6150c7710c8ba95e1b0b4919f04f
   speed: 1
@@ -7461,10 +7461,10 @@ HAIMAN_CORAL_PRODUCER:
   item:
     name: '&d&l珊瑚养殖机'
     lore:
-    - '&7自动培育珊瑚'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 6000 J 可存储'
-    - '&8⇨ &e⚡&7 120 J/s'
+      - '&7自动培育珊瑚'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 6000 J 可存储'
+      - '&8⇨ &e⚡&7 120 J/s'
     material_type: skull_hash
     material: d8f9d9072d7fd1b5175e788a27e0ff050ecbe425f7e79d5f28226c2fdb7dc167
   speed: 1
@@ -7697,10 +7697,10 @@ NONE_NBT_MACHINE:
   item:
     name: '&3&l无标签物品制作机'
     lore:
-    - '&7制作各种无标签物品'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1000 J 可存储'
-    - '&8⇨ &e⚡&7 60 J/s'
+      - '&7制作各种无标签物品'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1000 J 可存储'
+      - '&8⇨ &e⚡&7 60 J/s'
     material_type: skull_hash
     material: 3fcc26189cf8394dabc5de9ff1964f2ed0e6e42887175f7be22e606d40487dd
   speed: 1
@@ -7849,10 +7849,10 @@ STRANGE_NETHER_GOO_MACHINE:
   item:
     name: '&5&l奇怪的下界粘液交易机'
     lore:
-    - '&7通过金锭来与它交易以获取奇怪的下界粘液'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 10000 J 可存储'
-    - '&8⇨ &e⚡&7 400 J/s'
+      - '&7通过金锭来与它交易以获取奇怪的下界粘液'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 10000 J 可存储'
+      - '&8⇨ &e⚡&7 400 J/s'
     material_type: skull_hash
     material: 17a6a747437cd6f1c2d0241f3e4002611c88c92921526b0ff1802b6926433feb
   speed: 1
@@ -7917,10 +7917,10 @@ LILY_PAD_MACHINE:
   item:
     name: '&a&l莲叶分子联合机'
     lore:
-    - '&7消耗大量电来合成莲叶'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 100000 J 可存储'
-    - '&8⇨ &e⚡&7 12000 J/s'
+      - '&7消耗大量电来合成莲叶'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 100000 J 可存储'
+      - '&8⇨ &e⚡&7 12000 J/s'
     material_type: skull_hash
     material: 40e68eaeda7848c241c8855757e176ce555f0200f2e9c5843608b740dedfedd3
   speed: 1
@@ -7985,10 +7985,10 @@ HAIMAN_WASHING_MACHINE:
   item:
     name: '&b&l盥洗机'
     lore:
-    - '&7自动清洗物品'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 200 J 可存储'
-    - '&8⇨ &e⚡&7 10 J/s'
+      - '&7自动清洗物品'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 200 J 可存储'
+      - '&8⇨ &e⚡&7 10 J/s'
     material_type: skull_hash
     material: c7de63d401f85eed8a5e08cfa6cb290c40b11a7c72b579b2f06e8bb4a8a7c099
   speed: 1
@@ -8057,10 +8057,10 @@ HAIMAN_ANVIL_BROKER:
   item:
     name: '&6&l铁砧破碎机'
     lore:
-    - '&7自动破坏铁砧'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 2550 J 可存储'
-    - '&8⇨ &e⚡&7 40 J/s'
+      - '&7自动破坏铁砧'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 2550 J 可存储'
+      - '&8⇨ &e⚡&7 40 J/s'
     material_type: skull_hash
     material: 5cbd9f5ec1ed007259996491e69ff649a3106cf920227b1bb3a71ee7a89863f
   speed: 1
@@ -8137,10 +8137,10 @@ HAIMAN_ANVIL_FIXER:
   item:
     name: '&a&l铁砧修复机'
     lore:
-    - '&7自动修复铁砧'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 2550 J 可存储'
-    - '&8⇨ &e⚡&7 40 J/s'
+      - '&7自动修复铁砧'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 2550 J 可存储'
+      - '&8⇨ &e⚡&7 40 J/s'
     material_type: skull_hash
     material: 7b2f2b7642b54490b9ffa1e0e1b296aad2b7a4edb9361e7e8e9903b64dbb8939
   speed: 1
@@ -8217,11 +8217,11 @@ HAIMAN_GRAVEL_CREATER:
   item:
     name: '&8&l沙砾转换机'
     lore:
-    - '&7将一组圆石转化成一组沙砾'
-    - '&764items/s'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 8500 J 可存储'
-    - '&8⇨ &e⚡&7 2000 J/s'
+      - '&7将一组圆石转化成一组沙砾'
+      - '&764items/s'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 8500 J 可存储'
+      - '&8⇨ &e⚡&7 2000 J/s'
     material_type: skull_hash
     material: 1ee115656bc220755c6d5bc87260c82141c253a34bc3db2bd72b727befcc0
   speed: 1
@@ -8286,11 +8286,11 @@ HAIMAN_END_PORTAL_FRAME_CREATER:
   item:
     name: '&2&l末地传送门框架构造机'
     lore:
-    - '&8将哭泣的黑曜石构造成末地传送门框架'
-    - '&7用扳手拆卸它'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1000000 J 可存储'
-    - '&8⇨ &e⚡&7 180000 J/s'
+      - '&8将哭泣的黑曜石构造成末地传送门框架'
+      - '&7用扳手拆卸它'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1000000 J 可存储'
+      - '&8⇨ &e⚡&7 180000 J/s'
     material: END_PORTAL_FRAME
   speed: 1
   recipe_type: ENHANCED_CRAFTING_TABLE
@@ -8354,10 +8354,10 @@ HAIMAN_WOOD_PEELER:
   item:
     name: '&a&l原木剥皮机'
     lore:
-    - '&7自动为原木剥皮'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 64 J 可存储'
-    - '&8⇨ &e⚡&7 32 J/s'
+      - '&7自动为原木剥皮'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 64 J 可存储'
+      - '&8⇨ &e⚡&7 32 J/s'
     material_type: skull_hash
     material: 1243ceca82338993c8718cac31672da31adc495384915db57d83967ab0ccb369
   speed: 1
@@ -8782,10 +8782,10 @@ INFESTED_MACHINE:
   item:
     name: '&c&l虫蚀机'
     lore:
-    - '&7将蠹虫塞进方块里'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 128 J 可存储'
-    - '&8⇨ &e⚡&7 64 J/s'
+      - '&7将蠹虫塞进方块里'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 128 J 可存储'
+      - '&8⇨ &e⚡&7 64 J/s'
     material_type: skull_hash
     material: 4ec1c3f7d09ce6c0cb48ed30b4596a5c14fae79def8bfd14a59fc1935600bc7b
   speed: 1
@@ -8922,10 +8922,10 @@ HAIMAN_INFINITY_OIL_PUMP:
   item:
     name: '&6&l无尽原油泵'
     lore:
-    - '&7无需进行地质扫描便可以不断泵出石油'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 6000 J 可存储'
-    - '&8⇨ &e⚡&7 1600 J/s'
+      - '&7无需进行地质扫描便可以不断泵出石油'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 6000 J 可存储'
+      - '&8⇨ &e⚡&7 1600 J/s'
     material_type: skull_hash
     material: 4a7d54ca45a398c364cebbffb5390ce5e0345e0c7bc5e863acabf57d1342c4bd
   speed: 1
@@ -8990,10 +8990,10 @@ SOIL_CHANGER:
   item:
     name: '&2&l土质改良机'
     lore:
-    - '&7用于改良土壤'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 120 J 可存储'
-    - '&8⇨ &e⚡&7 48 J/s'
+      - '&7用于改良土壤'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 120 J 可存储'
+      - '&8⇨ &e⚡&7 48 J/s'
     material_type: skull_hash
     material: 6c07d48fd8764bc8d01a10cc6426578862090d9e856f3a8dd7f974a7521efc43
   speed: 1
@@ -9298,10 +9298,10 @@ HAIMAN_12K_GOLD_PRODUCER:
   item:
     name: '&e&l12k金一体机'
     lore:
-    - '&7直接将金粉熔铸成12k金'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 3000 J 可存储'
-    - '&8⇨ &e⚡&7 1200 J/s'
+      - '&7直接将金粉熔铸成12k金'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 3000 J 可存储'
+      - '&8⇨ &e⚡&7 1200 J/s'
     material_type: skull_hash
     material: 9fef722da05ae8bd8132905a11b5b6dfbf8e7ae0af599c8266e160fb05e6159b
   speed: 1
@@ -9366,10 +9366,10 @@ HAIMAN_24K_GOLD_PRODUCER:
   item:
     name: '&e&l24k金一体机'
     lore:
-    - '&7直接将金粉熔铸成24k金'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 6000 J 可存储'
-    - '&8⇨ &e⚡&7 2400 J/s'
+      - '&7直接将金粉熔铸成24k金'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 6000 J 可存储'
+      - '&8⇨ &e⚡&7 2400 J/s'
     material_type: skull_hash
     material: 9fef722da05ae8bd8132905a11b5b6dfbf8e7ae0af599c8266e160fb05e6159b
   speed: 1
@@ -9434,11 +9434,11 @@ HAIMAN_VOID_INGOT_PRODUCER:
   item:
     name: '&8&l虚空锭一体机'
     lore:
-    - '&7全自动一体化生产虚空锭'
-    - '&7并且所需的虚空粒也大大减少'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 60000 J 可存储'
-    - '&8⇨ &e⚡&7 6000 J/s'
+      - '&7全自动一体化生产虚空锭'
+      - '&7并且所需的虚空粒也大大减少'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 60000 J 可存储'
+      - '&8⇨ &e⚡&7 6000 J/s'
     material_type: skull_hash
     material: 1fac8a0c13a5a3674760a8f5e3d1a2340adebbc1a58653bee9568324a1eb33ca
   speed: 1
@@ -9503,10 +9503,10 @@ HAIMAN_AUTO_JUICER:
   item:
     name: '&6&l电动榨汁机'
     lore:
-    - '&7全自动榨果汁'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 128 J 可存储'
-    - '&8⇨ &e⚡&7 32 J/s'
+      - '&7全自动榨果汁'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 128 J 可存储'
+      - '&8⇨ &e⚡&7 32 J/s'
     material_type: skull_hash
     material: 666070ce03a545ee4d263bcf27f36338d249d7cb7a2376f92c1673ae134e04b6
   speed: 1
@@ -9643,10 +9643,10 @@ GRASS_WOOD_CHANGER:
   item:
     name: '&a&l草木改良机'
     lore:
-    - '&8对植物进行改良'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 36 J 可存储'
-    - '&8⇨ &e⚡&7 12 J/s'
+      - '&8对植物进行改良'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 36 J 可存储'
+      - '&8⇨ &e⚡&7 12 J/s'
     material_type: skull_hash
     material: 6945886fc40dfd7dcb09531f13a7b55dae92de52254da3d53636ef93bdc571
   speed: 1
@@ -9666,7 +9666,7 @@ GRASS_WOOD_CHANGER:
       amount: 1
     4:
       material_type: mc
-      material: GRASS
+      material: SHORT_GRASS
       amount: 1
     5:
       material_type: slimefun
@@ -9674,7 +9674,7 @@ GRASS_WOOD_CHANGER:
       amount: 1
     6:
       material_type: mc
-      material: GRASS
+      material: SHORT_GRASS
       amount: 1
     7:
       material_type: slimefun
@@ -9708,7 +9708,7 @@ GRASS_WOOD_CHANGER:
       input:
         1:
           material_type: mc
-          material: GRASS
+          material: SHORT_GRASS
           amount: 1
       output:
         1:
@@ -9747,10 +9747,10 @@ VERSIONED_GRASS_WOOD_CHANGER:
   item:
     name: '&a&l草木改良机'
     lore:
-    - '&8对植物进行改良'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 36 J 可存储'
-    - '&8⇨ &e⚡&7 12 J/s'
+      - '&8对植物进行改良'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 36 J 可存储'
+      - '&8⇨ &e⚡&7 12 J/s'
     material_type: skull_hash
     material: 6945886fc40dfd7dcb09531f13a7b55dae92de52254da3d53636ef93bdc571
   speed: 1
@@ -9846,7 +9846,7 @@ VERSIONED_GRASS_WOOD_CHANGER:
   id_alias: GRASS_WOOD_CHANGER
   register:
     conditions:
-    - version >= 1.20.3
+      - version >= 1.20.3
   input: [0, 1, 2, 9, 10, 11, 13, 18, 19, 20, 27, 28, 29, 30, 36, 37, 38, 39, 45, 46, 47, 48]
   output: [6, 7, 8, 15, 16, 17, 24, 25, 26, 32, 33, 34, 35, 41, 42, 43, 44, 50, 51, 52, 53]
 HAIMAN_COPPER_DUST_PRODUCER:
@@ -9855,10 +9855,10 @@ HAIMAN_COPPER_DUST_PRODUCER:
   item:
     name: '&c&l铜粉转换机'
     lore:
-    - '&7将其它矿粉转换成铜粉'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 120000 J 可存储'
-    - '&8⇨ &e⚡&7 10000 J/s'
+      - '&7将其它矿粉转换成铜粉'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 120000 J 可存储'
+      - '&8⇨ &e⚡&7 10000 J/s'
     material_type: skull_hash
     material: 8976aba47b5b6781915568100e99112467141ad35237557fff014c0275770cdc
   speed: 1
@@ -10007,10 +10007,10 @@ HAIMAN_IRON_DUST_PRODUCER:
   item:
     name: '&f&l铁粉转换机'
     lore:
-    - '&7将其它矿粉转换成铁粉'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 120000 J 可存储'
-    - '&8⇨ &e⚡&7 10000 J/s'
+      - '&7将其它矿粉转换成铁粉'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 120000 J 可存储'
+      - '&8⇨ &e⚡&7 10000 J/s'
     material_type: skull_hash
     material: 3eeb9d745dbc318030869ed92cf2be18bcf93bd5b1171c2019476b57331b3eab
   speed: 1
@@ -10159,12 +10159,12 @@ CORAL_DEAD_MACHINE:
   item:
     name: '&d&l珊瑚失活机'
     lore:
-    - '&7因为凋零的珊瑚无法通过其它途径获取'
-    - '&7（包括精准采集）'
-    - '&7所以这个机器可以让您获取失活的珊瑚'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 800 J 可存储'
-    - '&8⇨ &e⚡&7 10 J/s'
+      - '&7因为凋零的珊瑚无法通过其它途径获取'
+      - '&7（包括精准采集）'
+      - '&7所以这个机器可以让您获取失活的珊瑚'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 800 J 可存储'
+      - '&8⇨ &e⚡&7 10 J/s'
     material_type: skull_hash
     material: 644e39a028327d20a66846804118a675546e225dde96765e2c21cc4826a6c21d
   speed: 1
@@ -10397,10 +10397,10 @@ HAIMAN_SUGAR_PRODUCER_MACHINE:
   item:
     name: '&e&l糖提取机'
     lore:
-    - '&7从水果和植物中提取糖'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 300 J 可存储'
-    - '&8⇨ &e⚡&7 60 J/s'
+      - '&7从水果和植物中提取糖'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 300 J 可存储'
+      - '&8⇨ &e⚡&7 60 J/s'
     material_type: skull_hash
     material: 215cd248e3fb7b038013a1d1487168df093a7bbedce4224b5c823d3ef681a784
   speed: 1
@@ -10549,10 +10549,10 @@ HAIMAN_DECOMPRESSOR_MACHINE_1:
   item:
     name: '&7&l解压机 &7- &eI'
     lore:
-    - '&7将方块解压'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 10000 J 可存储'
-    - '&8⇨ &e⚡&7 200 J/s'
+      - '&7将方块解压'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 10000 J 可存储'
+      - '&8⇨ &e⚡&7 200 J/s'
     material_type: skull_hash
     material: e48337f7ede15c3b2f8dc6a63bd92874cdf74ec862b4118c7e35559ce8b4d
   speed: 1
@@ -10773,10 +10773,10 @@ HAIMAN_DECOMPRESSOR_MACHINE_2:
   item:
     name: '&7&l解压机 &7- &eII'
     lore:
-    - '&7将方块解压'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 12000 J 可存储'
-    - '&8⇨ &e⚡&7 240 J/s'
+      - '&7将方块解压'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 12000 J 可存储'
+      - '&8⇨ &e⚡&7 240 J/s'
     material_type: skull_hash
     material: e48337f7ede15c3b2f8dc6a63bd92874cdf74ec862b4118c7e35559ce8b4d
   speed: 1
@@ -10997,12 +10997,12 @@ HAIMAN_FISH_MACHINE:
   item:
     name: '&9&l网鱼机'
     lore:
-    - '&7将鱼网回桶里'
-    - '&7注：该机器生产出的热带鱼桶/美西螈桶'
-    - '&7可以放养出随机的热带鱼/美西螈'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 4800 J 可存储'
-    - '&8⇨ &e⚡&7 240 J/s'
+      - '&7将鱼网回桶里'
+      - '&7注：该机器生产出的热带鱼桶/美西螈桶'
+      - '&7可以放养出随机的热带鱼/美西螈'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 4800 J 可存储'
+      - '&8⇨ &e⚡&7 240 J/s'
     material_type: skull_hash
     material: 2481e6f7369cdb29dc0702372e5a4dfdb9875ee6aced87b701f81999c0fdd195
   speed: 1
@@ -11127,10 +11127,10 @@ HAIMAN_FOOD_FERMENTATION_MACHINE:
   item:
     name: '&3&l食品发酵机'
     lore:
-    - '&7可以用来发酵土豆和蜘蛛眼'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 2000 J 可存储'
-    - '&8⇨ &e⚡&7 40 J/s'
+      - '&7可以用来发酵土豆和蜘蛛眼'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 2000 J 可存储'
+      - '&8⇨ &e⚡&7 40 J/s'
     material_type: skull_hash
     material: 80823d1eccec41a412e29b5d9f3d1246c206a18d9a0f7a0f844077931e83cde1
   speed: 1
@@ -11207,10 +11207,10 @@ SYNTHETIC_CHANGER:
   item:
     name: '&5&l人造改良机'
     lore:
-    - '&7自动化生产人造材料'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 32000 J 可存储'
-    - '&8⇨ &e⚡&7 16000 J/s'
+      - '&7自动化生产人造材料'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 32000 J 可存储'
+      - '&8⇨ &e⚡&7 16000 J/s'
     material_type: skull_hash
     material: fdcccca8e9a518285e0352b43182f5845b1a66b9f09b450222c6e21005b6ca1a
   speed: 1
@@ -11311,10 +11311,10 @@ HAIMAN_BANNER_PATTERN_PRODUCER:
   item:
     name: '&e&l旗帜图案印刷机'
     lore:
-    - '&7用于印刷旗帜图案'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 4800 J 可存储'
-    - '&8⇨ &e⚡&7 480 J/s'
+      - '&7用于印刷旗帜图案'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 4800 J 可存储'
+      - '&8⇨ &e⚡&7 480 J/s'
     material_type: skull_hash
     material: 2de1a9fc8ddd772b3518bb955fd4dc7e83dcd54c12a357c1b2238102a15ce48c
   speed: 1
@@ -11439,10 +11439,10 @@ HAIMAN_LUMP_PRODUCER:
   item:
     name: '&c&l结晶一体机'
     lore:
-    - '&7一体化制作魔法结晶3和末影结晶3'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 12000 J 可存储'
-    - '&8⇨ &e⚡&7 2400 J/s'
+      - '&7一体化制作魔法结晶3和末影结晶3'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 12000 J 可存储'
+      - '&8⇨ &e⚡&7 2400 J/s'
     material_type: skull_hash
     material: 3625be5ba96fc11448aaddb915a390391c3f92f4af81a4a2adb0e3f4f65
   speed: 1
@@ -11519,10 +11519,10 @@ MUSIC_DISC_PRODUCER:
   item:
     name: '&b&l唱片刻印机'
     lore:
-    - '&7自动刻印唱片'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 6400 J 可存储'
-    - '&8⇨ &e⚡&7 128 J/s'
+      - '&7自动刻印唱片'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 6400 J 可存储'
+      - '&8⇨ &e⚡&7 128 J/s'
     material_type: skull_hash
     material: bef1a5afa3a51413880ae7b2ac99a12877573dc404646942bef2d932a3845974
   speed: 1
@@ -11767,10 +11767,10 @@ HAIMAN_HORSE_ARMOR_PRODUCER:
   item:
     name: '&6&l马具打造机'
     lore:
-    - '&7自动打造马铠和鞍'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 64 J 可存储'
-    - '&8⇨ &e⚡&7 16 J/s'
+      - '&7自动打造马铠和鞍'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 64 J 可存储'
+      - '&8⇨ &e⚡&7 16 J/s'
     material_type: skull_hash
     material: 1df28744ee147851b9ec2d491a65a47ede1a521000b535106dc3b1fbf6471481
   speed: 1
@@ -11883,11 +11883,11 @@ HAIMAN_STONE_CHANGER:
   item:
     name: '&6&l石化机'
     lore:
-    - '&7通过改造物品结构将物品石化'
-    - '&7可以制作石化橡木台阶'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 128 J 可存储'
-    - '&8⇨ &e⚡&7 32 J/s'
+      - '&7通过改造物品结构将物品石化'
+      - '&7可以制作石化橡木台阶'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 128 J 可存储'
+      - '&8⇨ &e⚡&7 32 J/s'
     material_type: skull_hash
     material: 3c9ca6078f4b34cd36de8ad0f23cb218ac7bbcd43ae15440f93607fd1356d6a
   speed: 1
@@ -12000,10 +12000,10 @@ HAIMAN_LEARHER_CHANGER:
   item:
     name: '&c&l皮质转换机'
     lore:
-    - '&7将皮革和兔子皮互相转换'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 60 J 可存储'
-    - '&8⇨ &e⚡&7 12 J/s'
+      - '&7将皮革和兔子皮互相转换'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 60 J 可存储'
+      - '&8⇨ &e⚡&7 12 J/s'
     material_type: skull_hash
     material: 8c335c9d963a10ca1fdce4c1ef3e20ae8bbd178e52720f2210cd0e662a90f035
   speed: 1
@@ -12092,10 +12092,10 @@ HAIMAN_CRAFTING_TABLE:
   item:
     name: '&f&l海曼工作台'
     lore:
-    - '&7用于制作1.17所无法合成的物品'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 240 J 可存储'
-    - '&8⇨ &e⚡&7 48 J/s'
+      - '&7用于制作1.17所无法合成的物品'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 240 J 可存储'
+      - '&8⇨ &e⚡&7 48 J/s'
     material_type: skull_hash
     material: abb84e348ab58be0435f61e027fa6dfe557bee8893f1c10c3c2bebd2025da
   speed: 1
@@ -12196,10 +12196,10 @@ HAIMAN_SOUL_MACHINE:
   item:
     name: '&f&l灵魂转换机'
     lore:
-    - '&7注入灵魂...'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 240 J 可存储'
-    - '&8⇨ &e⚡&7 48 J/s'
+      - '&7注入灵魂...'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 240 J 可存储'
+      - '&8⇨ &e⚡&7 48 J/s'
     material_type: skull_hash
     material: 9580e5cd970c1ded973d0c139be418b0755e0713345d716ed594244a53e6e13d
   speed: 1
@@ -12312,10 +12312,10 @@ HAIMAN_CONCRETE_DYING:
   item:
     name: '&6&l混凝土染坊'
     lore:
-    - '&7可以对混凝土等进行染色'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1000 J 可存储'
-    - '&8⇨ &e⚡&7 20 J/s'
+      - '&7可以对混凝土等进行染色'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1000 J 可存储'
+      - '&8⇨ &e⚡&7 20 J/s'
     material_type: skull_hash
     material: c69e3e6e5b2b92f0beb368b738b993d7ba225bf9bb2758bfc9fc2daba4a5a7d
   speed: 1
@@ -12752,10 +12752,10 @@ HAIMAN_WOOL_DYING:
   item:
     name: '&6&l羊毛染坊'
     lore:
-    - '&7可以对羊毛、床等进行染色'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1000 J 可存储'
-    - '&8⇨ &e⚡&7 20 J/s'
+      - '&7可以对羊毛、床等进行染色'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1000 J 可存储'
+      - '&8⇨ &e⚡&7 20 J/s'
     material_type: skull_hash
     material: 6e64a08dd535f57bd9bc4bdf698864fb247a353828d5db8907b25738c3c4
   speed: 1
@@ -13384,10 +13384,10 @@ HAIMAN_GLASS_DYING:
   item:
     name: '&6&l玻璃染坊'
     lore:
-    - '&7可以对玻璃等进行染色'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1000 J 可存储'
-    - '&8⇨ &e⚡&7 20 J/s'
+      - '&7可以对玻璃等进行染色'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1000 J 可存储'
+      - '&8⇨ &e⚡&7 20 J/s'
     material_type: skull_hash
     material: 70dc47e9d26342ee89875628b496aada5b0b437a94334c54e56cdaff471a93ca
   speed: 1
@@ -13848,10 +13848,10 @@ HAIMAN_TERRACOTTA_DYING:
   item:
     name: '&6&l陶瓦染坊'
     lore:
-    - '&7可以对陶瓦等进行染色'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1000 J 可存储'
-    - '&8⇨ &e⚡&7 20 J/s'
+      - '&7可以对陶瓦等进行染色'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1000 J 可存储'
+      - '&8⇨ &e⚡&7 20 J/s'
     material_type: skull_hash
     material: b87fd23a78369bd3875da8896f150c4af9f23374e048e30913900e3fdd77859a
   speed: 1
@@ -14300,10 +14300,10 @@ HAIMAN_SHULKER_BOX_DYING:
   item:
     name: '&6&l潜影盒染坊'
     lore:
-    - '&7可以对潜影盒进行染色'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1000 J 可存储'
-    - '&8⇨ &e⚡&7 20 J/s'
+      - '&7可以对潜影盒进行染色'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1000 J 可存储'
+      - '&8⇨ &e⚡&7 20 J/s'
     material_type: skull_hash
     material: 71e5bd12982b1ba1b9e60c24268f891c6a70a68b95e03efea58813a8df083a9f
   speed: 1
@@ -14560,10 +14560,10 @@ HAIMAN_CANDLE_DYING:
   item:
     name: '&6&l蜡烛染坊'
     lore:
-    - '&7可以对蜡烛进行染色'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1000 J 可存储'
-    - '&8⇨ &e⚡&7 20 J/s'
+      - '&7可以对蜡烛进行染色'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1000 J 可存储'
+      - '&8⇨ &e⚡&7 20 J/s'
     material_type: skull_hash
     material: a886311259a9ffd5a1274b48fcc6238ec3ff2bd739ca9ea84586f9c6585a8047
   speed: 1
@@ -14820,10 +14820,10 @@ HAIMAN_BANNER_DYING:
   item:
     name: '&6&l旗帜染坊'
     lore:
-    - '&7可以对旗帜进行染色'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1000 J 可存储'
-    - '&8⇨ &e⚡&7 20 J/s'
+      - '&7可以对旗帜进行染色'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1000 J 可存储'
+      - '&8⇨ &e⚡&7 20 J/s'
     material_type: skull_hash
     material: 76184610c50c2efb7285bc2d20f394364e8367bb314841c238a6a521a1ee12bf
   speed: 1
@@ -15068,12 +15068,12 @@ HAIMAN_ADVANCE_DYING:
   item:
     name: '&4&l终极染坊'
     lore:
-    - '&7对物品进行终极染色'
-    - '&7如果想要机器输出彩虹方块'
-    - '&7须要在输入槽内放入相应的彩虹方块'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1000 J 可存储'
-    - '&8⇨ &e⚡&7 20 J/s'
+      - '&7对物品进行终极染色'
+      - '&7如果想要机器输出彩虹方块'
+      - '&7须要在输入槽内放入相应的彩虹方块'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1000 J 可存储'
+      - '&8⇨ &e⚡&7 20 J/s'
     material_type: skull_hash
     material: 391255206efac82b7e5ed6ce4b1ae5669ce55d087099299811007148bd1c8ece
   speed: 1
@@ -15450,13 +15450,13 @@ HAIMAN_BLOCK_DYING:
   item:
     name: '&c&l染色方块浇筑机'
     lore:
-    - '&7一个可以量产染色方块的机器'
-    - '&7包含所有染色方块'
-    - '&7须在输入槽内放入相应的染色方块'
-    - '&7输入槽内的染色方块不会被消耗'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1200 J 可存储'
-    - '&8⇨ &e⚡&7 240 J/s'
+      - '&7一个可以量产染色方块的机器'
+      - '&7包含所有染色方块'
+      - '&7须在输入槽内放入相应的染色方块'
+      - '&7输入槽内的染色方块不会被消耗'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1200 J 可存储'
+      - '&8⇨ &e⚡&7 240 J/s'
     material_type: skull_hash
     material: 67844a5b74f341039560f280db1fcdf836e3b6a48dc2a09351937626977e1c2
   speed: 1
@@ -17873,10 +17873,10 @@ HAIMAN_LIGHT_PRODUCER:
   item:
     name: '&e&l电光聚合机'
     lore:
-    - '&7用于制造隐形光源'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 50000 J 可存储'
-    - '&8⇨ &e⚡&7 10000 J/s'
+      - '&7用于制造隐形光源'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 50000 J 可存储'
+      - '&8⇨ &e⚡&7 10000 J/s'
     material_type: skull_hash
     material: 366335847cba9aeaffc95cb109fdf55da13c95c97326a3bf5ddc7c99ee3
   speed: 1
@@ -17941,10 +17941,10 @@ HAIMAN_LIGHT_UPDATER:
   item:
     name: '&e&l电光升级机'
     lore:
-    - '&7用于升级光源方块'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 50000 J 可存储'
-    - '&8⇨ &e⚡&7 11000 J/s'
+      - '&7用于升级光源方块'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 50000 J 可存储'
+      - '&8⇨ &e⚡&7 11000 J/s'
     material_type: skull_hash
     material: 59d0f51f39e08e51cc83cbec01e3ce1362c70c02edc351902af8e7a5f6e201bc
   speed: 1
@@ -18189,10 +18189,10 @@ HAIMAN_CAVE_MACHINE:
   item:
     name: '&c&l洞穴环境模拟机'
     lore:
-    - '&7自动生产紫水晶/滴水石锥'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 60000 J 可存储'
-    - '&8⇨ &e⚡&7 120 J/s'
+      - '&7自动生产紫水晶/滴水石锥'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 60000 J 可存储'
+      - '&8⇨ &e⚡&7 120 J/s'
     material_type: skull_hash
     material: de31efefdd9551af8a4349d3d21e5ec8f37e53c801eb25b14279d6a89fe0c01e
   speed: 1
@@ -18353,10 +18353,10 @@ HAIMAN_POWDER_SNOW_MACHINE:
   item:
     name: '&b&l细雪收集机'
     lore:
-    - '&7自动收集细雪'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 100 J 可存储'
-    - '&8⇨ &e⚡&7 8 J/s'
+      - '&7自动收集细雪'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 100 J 可存储'
+      - '&8⇨ &e⚡&7 8 J/s'
     material_type: skull_hash
     material: 152353641d287ce9ed30906f938ae9c517ec04caa8da71571954c81b09db454c
   speed: 1
@@ -18421,10 +18421,10 @@ HAIMAN_RAW_INGOT_CHANGER:
   item:
     name: '&d&l粗精矿转换机'
     lore:
-    - '&7转换粗矿和精矿，并给予你额外矿物'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 60000 J 可存储'
-    - '&8⇨ &e⚡&7 2400 J/s'
+      - '&7转换粗矿和精矿，并给予你额外矿物'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 60000 J 可存储'
+      - '&8⇨ &e⚡&7 2400 J/s'
     material_type: skull_hash
     material: d51e24cc2593947d1f96abe746116911ff75d12b5883ab5fd85fdb16316f6894
   speed: 1
@@ -18549,10 +18549,10 @@ HAIMAN_ORE_CHANGER:
   item:
     name: '&6&l矿石材质转换机'
     lore:
-    - '&7用于转换矿石材质'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 2600 J 可存储'
-    - '&8⇨ &e⚡&7 40 J/s'
+      - '&7用于转换矿石材质'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 2600 J 可存储'
+      - '&8⇨ &e⚡&7 40 J/s'
     material_type: skull_hash
     material: 93e289e4918fb5fa70608c1396c73818a6d12bcaaf4035c07300935e811271ad
   speed: 1
@@ -18821,10 +18821,10 @@ HAIMAN_GLOWER:
   item:
     name: '&e&l荧光镀灼机'
     lore:
-    - '&7给物品镀上荧光'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 5000 J 可存储'
-    - '&8⇨ &e⚡&7 100 J/s'
+      - '&7给物品镀上荧光'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 5000 J 可存储'
+      - '&8⇨ &e⚡&7 100 J/s'
     material_type: skull_hash
     material: e7834775336a2f538673991be076c874c7fad11b7b7f4f32143b633e043121
   speed: 1
@@ -18937,10 +18937,10 @@ HAIMAN_COPPER_INGOT_CHANGER:
   item:
     name: '&e&l铜锭转换机'
     lore:
-    - '&7将1.17的铜锭转换为粘液科技的铜锭'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 4500 J 可存储'
-    - '&8⇨ &e⚡&7 4000 J/s'
+      - '&7将1.17的铜锭转换为粘液科技的铜锭'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 4500 J 可存储'
+      - '&8⇨ &e⚡&7 4000 J/s'
     material_type: skull_hash
     material: 415e470805d5fc611c44b87c39e7e4dfd474049b24f3f6bba230e250f9b4b87c
   speed: 1
@@ -19017,10 +19017,10 @@ HAIMAN_WAX_ON_MACHINE:
   item:
     name: '&6&l涂蜡机'
     lore:
-    - '&7自动为铜制方块涂蜡'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 64 J 可存储'
-    - '&8⇨ &e⚡&7 8 J/s'
+      - '&7自动为铜制方块涂蜡'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 64 J 可存储'
+      - '&8⇨ &e⚡&7 8 J/s'
     material_type: skull_hash
     material: abe1770540be1eaf7e5b1180c6931179e2c4683daf6f01d0151f823f3e6ab940
   speed: 1
@@ -19265,10 +19265,10 @@ HAIMAN_WAX_OFF_MACHINE:
   item:
     name: '&8&l脱蜡机'
     lore:
-    - '&7自动为铜制方块脱蜡'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 64 J 可存储'
-    - '&8⇨ &e⚡&7 8 J/s'
+      - '&7自动为铜制方块脱蜡'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 64 J 可存储'
+      - '&8⇨ &e⚡&7 8 J/s'
     material_type: skull_hash
     material: a54947de7f52598255d6afee9d77befad9b4f24c0c4663d28bcdf8a6457f34
   speed: 1
@@ -19497,10 +19497,10 @@ HAIMAN_OXIDIZED_MACHINE:
   item:
     name: '&9&l氧化机'
     lore:
-    - '&7自动氧化铜制方块'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 64 J 可存储'
-    - '&8⇨ &e⚡&7 16 J/s'
+      - '&7自动氧化铜制方块'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 64 J 可存储'
+      - '&8⇨ &e⚡&7 16 J/s'
     material_type: skull_hash
     material: 31885b918104e6aa62b6ec9b8e82028dd9da7d2acdfe9c2155edd392285b57e1
   speed: 1
@@ -19697,10 +19697,10 @@ HAIMAN_RUST_REMOVAL_MACHINE:
   item:
     name: '&a&l除锈机'
     lore:
-    - '&7自动给被氧化的铜制方块除锈'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 64 J 可存储'
-    - '&8⇨ &e⚡&7 16 J/s'
+      - '&7自动给被氧化的铜制方块除锈'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 64 J 可存储'
+      - '&8⇨ &e⚡&7 16 J/s'
     material_type: skull_hash
     material: 60ce43e0cdcea98dcc6f0be37b0f7745daaf2a7dc29bf13b3e78a65c6e
   speed: 1
@@ -19881,9 +19881,9 @@ HAIMAN_ELECTRIC_INGOT_FACTORY_4:
   item:
     name: '&c电动铸锭机 &7(&eIV&7)'
     lore:
-    - '&b机器'
-    - '&8⇨ &e⚡&7 160 J 可存储'
-    - '&8⇨ &e⚡&7 160 J/s'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 160 J 可存储'
+      - '&8⇨ &e⚡&7 160 J/s'
     material: RED_TERRACOTTA
   speed: 1
   recipe_type: ENHANCED_CRAFTING_TABLE
@@ -20043,9 +20043,9 @@ HAIMAN_ELECTRIC_INGOT_FACTORY_5:
   item:
     name: '&c电动铸锭机 &7(&eV&7)'
     lore:
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1600 J 可存储'
-    - '&8⇨ &e⚡&7 640 J/s'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1600 J 可存储'
+      - '&8⇨ &e⚡&7 640 J/s'
     material: RED_TERRACOTTA
   speed: 1
   recipe_type: ENHANCED_CRAFTING_TABLE
@@ -20205,9 +20205,9 @@ HAIMAN_CARBON_PRESS_4:
   item:
     name: '&c碳压机 &7- &eIV'
     lore:
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1600 J 可存储'
-    - '&8⇨ &e⚡&7 640 J/s'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1600 J 可存储'
+      - '&8⇨ &e⚡&7 640 J/s'
     material: BLACK_STAINED_GLASS
   speed: 1
   recipe_type: ENHANCED_CRAFTING_TABLE
@@ -20331,11 +20331,11 @@ HAIMAN_CARBON_PRESS_5:
   item:
     name: '&c碳压机 &7- &eV'
     lore:
-    - '&7该等级的碳压机'
-    - '&7可以将8个压缩碳压为1个碳块'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 3200 J 可存储'
-    - '&8⇨ &e⚡&7 1280 J/s'
+      - '&7该等级的碳压机'
+      - '&7可以将8个压缩碳压为1个碳块'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 3200 J 可存储'
+      - '&8⇨ &e⚡&7 1280 J/s'
     material: BLACK_STAINED_GLASS
   speed: 1
   recipe_type: ENHANCED_CRAFTING_TABLE
@@ -20471,10 +20471,10 @@ HAIMAN_FUEL_MACHINE:
   item:
     name: '&a&l燃料液化机'
     lore:
-    - '&7用于液化燃料'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 950000 J 可存储'
-    - '&8⇨ &e⚡&7 90000 J/s'
+      - '&7用于液化燃料'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 950000 J 可存储'
+      - '&8⇨ &e⚡&7 90000 J/s'
     material_type: skull_hash
     material: 6080972b7c32da650cc86e9aad665ed8d0d48a3bdb0ba234d4fceac024c7952e
   speed: 1
@@ -20575,11 +20575,11 @@ HAIMAN_CARPET_MACHINE:
   item:
     name: '&9&l刷地毯机'
     lore:
-    - '&7自动复制各种地毯'
-    - '&7须在输入槽内放入相应的地毯'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1000 J 可存储'
-    - '&8⇨ &e⚡&7 30 J/s'
+      - '&7自动复制各种地毯'
+      - '&7须在输入槽内放入相应的地毯'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1000 J 可存储'
+      - '&8⇨ &e⚡&7 30 J/s'
     material_type: skull_hash
     material: 82c3c18263331e1a2c02fd78031f9b0a433ca6957e677abb6d879c330c87c2e
   speed: 1
@@ -20836,11 +20836,11 @@ HAIMAN_RAIL_MACHINE_1:
   item:
     name: '&9&l刷铁轨机 &7- &eI'
     lore:
-    - '&7自动复制各种原版铁轨'
-    - '&7须在输入槽内放入相应的铁轨'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 2500 J 可存储'
-    - '&8⇨ &e⚡&7 50 J/s'
+      - '&7自动复制各种原版铁轨'
+      - '&7须在输入槽内放入相应的铁轨'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 2500 J 可存储'
+      - '&8⇨ &e⚡&7 50 J/s'
     material_type: skull_hash
     material: 3b925d3a52759fde8c0258871fefd9141e5c97fdf453af3df21104cc8c488
   speed: 1
@@ -20941,11 +20941,11 @@ HAIMAN_RAIL_MACHINE_2:
   item:
     name: '&9&l刷铁轨机 &7- &eII'
     lore:
-    - '&7自动复制各种原版铁轨'
-    - '&7须在输入槽内放入相应的铁轨'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 2500 J 可存储'
-    - '&8⇨ &e⚡&7 50 J/s'
+      - '&7自动复制各种原版铁轨'
+      - '&7须在输入槽内放入相应的铁轨'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 2500 J 可存储'
+      - '&8⇨ &e⚡&7 50 J/s'
     material_type: skull_hash
     material: 3b925d3a52759fde8c0258871fefd9141e5c97fdf453af3df21104cc8c488
   speed: 1
@@ -21046,10 +21046,10 @@ HAIMAN_MINECART_MACHINE:
   item:
     name: '&c&l矿车装配机'
     lore:
-    - '&7自动装配各种矿车'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 2500 J 可存储'
-    - '&8⇨ &e⚡&7 100 J/s'
+      - '&7自动装配各种矿车'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 2500 J 可存储'
+      - '&8⇨ &e⚡&7 100 J/s'
     material_type: skull_hash
     material: d4b881b2b719815cfe630bd358d2fe033f540e2250ad3dbccae445ff99ac815e
   speed: 1
@@ -21194,10 +21194,10 @@ HAIMAN_BOOK_MACHINE:
   item:
     name: '&c&l书厂'
     lore:
-    - '&7自动生产各种书'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 8600 J 可存储'
-    - '&8⇨ &e⚡&7 160 J/s'
+      - '&7自动生产各种书'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 8600 J 可存储'
+      - '&8⇨ &e⚡&7 160 J/s'
     material_type: skull_hash
     material: e344d83e7c6ece90d34c685a9a3384f8e8d0151633fc2eeae4d4b636862d33
   speed: 1
@@ -21382,10 +21382,10 @@ HAIMAN_DEBUG_MACHINE:
   item:
     name: '&9&lDebug调试机'
     lore:
-    - '&7???...调试?'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 60000 J 可存储'
-    - '&8⇨ &e⚡&7 12000 J/s'
+      - '&7???...调试?'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 60000 J 可存储'
+      - '&8⇨ &e⚡&7 12000 J/s'
     material_type: skull_hash
     material: c5db573730904041dee937beeada8b0182351924a42f9979513cf0bd433be077
   speed: 1
@@ -21462,10 +21462,10 @@ HAIMAN_JINGLIANLU:
   item:
     name: '&e&l初级精炼炉'
     lore:
-    - '&7用于自动生产精炼铁'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1200 J 可存储'
-    - '&8⇨ &e⚡&7 120 J/s'
+      - '&7用于自动生产精炼铁'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1200 J 可存储'
+      - '&8⇨ &e⚡&7 120 J/s'
     material_type: skull_hash
     material: 382d58e893bf9b82433626d0e480e9375b58f3c2ddef450f617b60dbf506cbb9
   speed: 1
@@ -21530,11 +21530,11 @@ HAIMAN_POWER_STORAGER_0:
   item:
     name: '&d&l元电荷储电机'
     lore:
-    - '&7将电能存入元电荷中'
-    - '&8电能的市场流通'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1250 J 可存储'
-    - '&8⇨ &e⚡&7 2500 J/s'
+      - '&7将电能存入元电荷中'
+      - '&8电能的市场流通'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1250 J 可存储'
+      - '&8⇨ &e⚡&7 2500 J/s'
     material_type: skull_hash
     material: 76f0a795a6e36798b7bac5513d43e3e6ce8182af74628ef8027313dd1818387
   speed: 1
@@ -21599,11 +21599,11 @@ HAIMAN_POWER_STORAGER_1:
   item:
     name: '&d&l储电机 &7- &aI'
     lore:
-    - '&7将电能存入电单元中'
-    - '&8电...的物品形式？'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1136 J 可存储'
-    - '&8⇨ &e⚡&7 2272 J/s'
+      - '&7将电能存入电单元中'
+      - '&8电...的物品形式？'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1136 J 可存储'
+      - '&8⇨ &e⚡&7 2272 J/s'
     material_type: skull_hash
     material: 208c18b4c66a08ffaf76b55d4247d3f367ef4c3df696ca97fcabe3269f7bd515
   speed: 1
@@ -21668,11 +21668,11 @@ HAIMAN_POWER_STORAGER_2:
   item:
     name: '&d&l储电机 &7- &eII'
     lore:
-    - '&7将电能存入电单元中'
-    - '&8经过改良之后能存更多电了'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 20456 J 可存储'
-    - '&8⇨ &e⚡&7 40912 J/s'
+      - '&7将电能存入电单元中'
+      - '&8经过改良之后能存更多电了'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 20456 J 可存储'
+      - '&8⇨ &e⚡&7 40912 J/s'
     material_type: skull_hash
     material: 918a00b1c5ef0ba6d83e54fcbabb6272764f165d57ce8a26a916d4192a54c966
   speed: 1
@@ -21749,11 +21749,11 @@ HAIMAN_POWER_STORAGER_3:
   item:
     name: '&d&l储电机 &7- &6III'
     lore:
-    - '&7将电能存入电单元中'
-    - '&8以便不时之需...'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 6628035 J 可存储'
-    - '&8⇨ &e⚡&7 13256070 J/s'
+      - '&7将电能存入电单元中'
+      - '&8以便不时之需...'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 6628035 J 可存储'
+      - '&8⇨ &e⚡&7 13256070 J/s'
     material_type: skull_hash
     material: ad78b536eed33a0f957a042cae0c9b1da7f3b0a651f8e31abc4890ebfce70c89
   speed: 1
@@ -21842,11 +21842,11 @@ HAIMAN_POWER_STORAGER_4:
   item:
     name: '&d&l储电机 &7- &cIV'
     lore:
-    - '&7将电能存入电单元中'
-    - '&8能源交易？'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 6628035 J 可存储'
-    - '&8⇨ &e⚡&7 13256070 J/s'
+      - '&7将电能存入电单元中'
+      - '&8能源交易？'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 6628035 J 可存储'
+      - '&8⇨ &e⚡&7 13256070 J/s'
     material_type: skull_hash
     material: 308b8eb060906e2926374c2cec8dcbb8c3b2dfea5820695ef51a15c5b1ca296c
   speed: 1
@@ -21947,11 +21947,11 @@ HAIMAN_POWER_STORAGER_5:
   item:
     name: '&d&l储电机 &7- &4V'
     lore:
-    - '&7将电能存入电单元中'
-    - '&8超越宇宙的便捷能源'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 2147483647 J 可存储'
-    - '&8⇨ &e⚡&7 4294967294 J/s'
+      - '&7将电能存入电单元中'
+      - '&8超越宇宙的便捷能源'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 2147483647 J 可存储'
+      - '&8⇨ &e⚡&7 4294967294 J/s'
     material_type: skull_hash
     material: b2d54d1e32a3da989172aee0dbc0b6ea103681298828abcb59daaa140d989342
   speed: 1
@@ -22064,10 +22064,10 @@ HAIMAN_DANGAO_HONGBEI:
   item:
     name: '&6&l烤箱'
     lore:
-    - '&7烘焙食材'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1200 J 可存储'
-    - '&8⇨ &e⚡&7 24 J/s'
+      - '&7烘焙食材'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1200 J 可存储'
+      - '&8⇨ &e⚡&7 24 J/s'
     material_type: skull_hash
     material: 8f9da46d97461a1be10600cc546a9d4613e16cfb5719eeb39042e501836008ca
   speed: 1
@@ -22312,10 +22312,10 @@ HAIMAN_MEAT_CHANGER:
   item:
     name: '&6&l肉质转换机'
     lore:
-    - '&7转换肉类的品种'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1000 J 可存储'
-    - '&8⇨ &e⚡&7 24 J/s'
+      - '&7转换肉类的品种'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1000 J 可存储'
+      - '&8⇨ &e⚡&7 24 J/s'
     material_type: skull_hash
     material: 318e35ec4b4b4c1591c5177386de18797454298b7455982e3ae83bacced0f1a2
   speed: 1
@@ -22560,10 +22560,10 @@ HAIMAN_BOTTLE_CHANGER:
   item:
     name: '&6&l水瓶转换机'
     lore:
-    - '&7回收各种炼药大师的水瓶'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1000 J 可存储'
-    - '&8⇨ &e⚡&7 24 J/s'
+      - '&7回收各种炼药大师的水瓶'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1000 J 可存储'
+      - '&8⇨ &e⚡&7 24 J/s'
     material_type: skull_hash
     material: 24378b986e358555ee73f09b210d49ec13719de5ea88d75523770d31163f3aef
   speed: 1
@@ -22760,10 +22760,10 @@ HAIMAN_WRITTEN_BOOK_CHANGER:
   item:
     name: '&6&l旧书机'
     lore:
-    - '&7使书看上去更有年代感'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 500 J 可存储'
-    - '&8⇨ &e⚡&7 12 J/s'
+      - '&7使书看上去更有年代感'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 500 J 可存储'
+      - '&8⇨ &e⚡&7 12 J/s'
     material_type: skull_hash
     material: 46ee7e906686abd5ec192b079314c45f1fb8171d9e13caa4cf9f63afc2263fd5
   speed: 1
@@ -22864,10 +22864,10 @@ HAIMAN_WRITTEN_BOOK_CHANGERNEW:
   item:
     name: '&d&l成书机'
     lore:
-    - '&7使旧书崭新出厂'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 500 J 可存储'
-    - '&8⇨ &e⚡&7 10 J/s'
+      - '&7使旧书崭新出厂'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 500 J 可存储'
+      - '&8⇨ &e⚡&7 10 J/s'
     material_type: skull_hash
     material: c10a26a87549e06e0669f6c48f61478d23025b91d90ea2c4b9f804b9f796d04c
   speed: 1
@@ -22968,10 +22968,10 @@ HAIMAN_YINGXING_MACHINE:
   item:
     name: '&b&l隐形机'
     lore:
-    - '&7将物品隐形化'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 8000 J 可存储'
-    - '&8⇨ &e⚡&7 600 J/s'
+      - '&7将物品隐形化'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 8000 J 可存储'
+      - '&8⇨ &e⚡&7 600 J/s'
     material_type: skull_hash
     material: 21172c389b9d6f80adec6b58ac4ca2a53ef549a65f5fdb74fcfbeac1ab4eb390
   speed: 1
@@ -23060,10 +23060,10 @@ HAIMAN_COFFEE_MAKER:
   item:
     name: '&c&l咖啡机'
     lore:
-    - '&7困了，就来杯咖啡吧'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 220 J 可存储'
-    - '&8⇨ &e⚡&7 40 J/s'
+      - '&7困了，就来杯咖啡吧'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 220 J 可存储'
+      - '&8⇨ &e⚡&7 40 J/s'
     material_type: skull_hash
     material: 4552f7375672a5737f2ab766e5d1bcbfe8e12913cc9f044b43a2123a35185665
   speed: 1
@@ -23128,13 +23128,13 @@ HAIMAN_YJ_SX_MACHINE:
   item:
     name: '&6&l遗迹搜寻机'
     lore:
-    - '&7搜寻当前世界的遗迹'
-    - '&7并获取遗迹中的宝箱'
-    - '&7须要将宝藏探测器'
-    - '&7放入非消耗型物品槽内'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 68000 J 可存储'
-    - '&8⇨ &e⚡&7 13600 J/s'
+      - '&7搜寻当前世界的遗迹'
+      - '&7并获取遗迹中的宝箱'
+      - '&7须要将宝藏探测器'
+      - '&7放入非消耗型物品槽内'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 68000 J 可存储'
+      - '&8⇨ &e⚡&7 13600 J/s'
     material_type: skull_hash
     material: b905dc824adacce5657bc98e4ad41b504544006376cb8dbcff98163414f80d6d
   speed: 1
@@ -23839,13 +23839,13 @@ HAIMAN_LU_CAT_MACHINE:
   item:
     name: '&d&l自动撸猫机'
     lore:
-    - '&7时间太紧，没空撸猫？'
-    - '&7快来试试这台机器吧！'
-    - '&7须要将逗猫棒'
-    - '&7放入非消耗型物品槽内'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 8000 J 可存储'
-    - '&8⇨ &e⚡&7 800 J/s'
+      - '&7时间太紧，没空撸猫？'
+      - '&7快来试试这台机器吧！'
+      - '&7须要将逗猫棒'
+      - '&7放入非消耗型物品槽内'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 8000 J 可存储'
+      - '&8⇨ &e⚡&7 800 J/s'
     material_type: skull_hash
     material: 25f32f6e85ceb4288a95e3b95dd5e795d1dc6549db624971275c82daf3c8e9db
   speed: 1
@@ -23918,10 +23918,10 @@ HAIMAN_ZLJY_MACHINE:
   item:
     name: '&c&l猪灵交易机'
     lore:
-    - '&7快来跟可爱的猪灵妹子交易吧！'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 4800 J 可存储'
-    - '&8⇨ &e⚡&7 240 J/s'
+      - '&7快来跟可爱的猪灵妹子交易吧！'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 4800 J 可存储'
+      - '&8⇨ &e⚡&7 240 J/s'
     material_type: skull_hash
     material: 15f9be6eaea4c6c43329ab512b17f5bfbcc453e11b5351ddb572df35f597dd9a
   speed: 1
@@ -23998,10 +23998,10 @@ HAIMAN_CMLW_MACHINE:
   item:
     name: '&a&l村民送礼机'
     lore:
-    - '&7当你是村庄英雄的时候...'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 9600 J 可存储'
-    - '&8⇨ &e⚡&7 480 J/s'
+      - '&7当你是村庄英雄的时候...'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 9600 J 可存储'
+      - '&8⇨ &e⚡&7 480 J/s'
     material_type: skull_hash
     material: d3b919f040922eb17733b42d216b7cdefeaea366be14c1ae6993ca7e5909e0f0
   speed: 1
@@ -24078,10 +24078,10 @@ HAIMAN_DUANZAO_MACHINE:
   item:
     name: '&b&l电动锻造台'
     lore:
-    - '&7自动升级钻石制工具、护甲等'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 2400 J 可存储'
-    - '&8⇨ &e⚡&7 240 J/s'
+      - '&7自动升级钻石制工具、护甲等'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 2400 J 可存储'
+      - '&8⇨ &e⚡&7 240 J/s'
     material_type: skull_hash
     material: 272d1be488d267ecbecf7fbc314390636e942b6460628b02104a838184b7e737
   speed: 1
@@ -24278,11 +24278,11 @@ XUESHIZHIPINGZHUANGPEIJI:
   item:
     name: '&b&l学识之瓶装配机'
     lore:
-    - '&7能够将怪物掉落物转换成学识之瓶'
-    - '&7终于可以利用怪物掉落物了'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 4096 J 可存储'
-    - '&8⇨ &e⚡&7 2048 J/s'
+      - '&7能够将怪物掉落物转换成学识之瓶'
+      - '&7终于可以利用怪物掉落物了'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 4096 J 可存储'
+      - '&8⇨ &e⚡&7 2048 J/s'
     material_type: skull_hash
     material: 63ae17c9efcbfdd87718ac080ac815cd8009c87f82c474444082a4d87eef7062
   speed: 1
@@ -24479,11 +24479,11 @@ KUANGWUCUISHENGQI:
   item:
     name: '&a&l矿物催生器'
     lore:
-    - '&7能够将一个矿石种子催化成熟'
-    - '&7想制造它非常容易'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1024 J 可存储'
-    - '&8⇨ &e⚡&7 32 J/s'
+      - '&7能够将一个矿石种子催化成熟'
+      - '&7想制造它非常容易'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1024 J 可存储'
+      - '&8⇨ &e⚡&7 32 J/s'
     material_type: skull_hash
     material: da88ab0af11230d3a4683e033354c428115d52a9588c93f3263512e440214600
   speed: 1
@@ -24644,11 +24644,11 @@ HEDIANZHAN_1:
   item:
     name: '&e&l核电站&c(I)'
     lore:
-    - '&7&l快速营造核辐射环境!'
-    - '&b&l⇨ 速度：1x'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1024 J 可存储'
-    - '&8⇨ &e⚡&7 240 J/s'
+      - '&7&l快速营造核辐射环境!'
+      - '&b&l⇨ 速度：1x'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1024 J 可存储'
+      - '&8⇨ &e⚡&7 240 J/s'
     material_type: skull_hash
     material: 7b7c9b6a23f21cca2b362b85b36dece3d8389e363014defe5b92ff6ee64f1ae
   speed: 1
@@ -24737,11 +24737,11 @@ HEDIANZHAN_2:
   item:
     name: '&e&l核电站&c(II)'
     lore:
-    - '&7&l快速营造核辐射环境!'
-    - '&b&l⇨ 速度：5x'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 2048 J 可存储'
-    - '&8⇨ &e⚡&7 600 J/s'
+      - '&7&l快速营造核辐射环境!'
+      - '&b&l⇨ 速度：5x'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 2048 J 可存储'
+      - '&8⇨ &e⚡&7 600 J/s'
     material_type: skull_hash
     material: 7b7c9b6a23f21cca2b362b85b36dece3d8389e363014defe5b92ff6ee64f1ae
   speed: 1
@@ -24830,11 +24830,11 @@ HELIEBIAN_3:
   item:
     name: '&c&l核裂变基地'
     lore:
-    - '&7&l超级制造!'
-    - '&b&l⇨ 速度：1000x'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 10000 J 可存储'
-    - '&8⇨ &e⚡&7 4096 J/s'
+      - '&7&l超级制造!'
+      - '&b&l⇨ 速度：1000x'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 10000 J 可存储'
+      - '&8⇨ &e⚡&7 4096 J/s'
     material_type: skull_hash
     material: 7b7c9b6a23f21cca2b362b85b36dece3d8389e363014defe5b92ff6ee64f1ae
   speed: 1
@@ -25011,11 +25011,11 @@ GJJLL:
   item:
     name: '&1&l高级精炼炉'
     lore:
-    - '&7&l自动制造精炼铁!'
-    - '&b&l⇨ 速度：10x'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1024 J 可存储'
-    - '&8⇨ &e⚡&7 60 J/s'
+      - '&7&l自动制造精炼铁!'
+      - '&b&l⇨ 速度：10x'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1024 J 可存储'
+      - '&8⇨ &e⚡&7 60 J/s'
     material_type: skull_hash
     material: 8296f092524ae9c2a2e87881cb415adb358d6cb773c85dc97202fefb754c1
   speed: 1
@@ -25080,12 +25080,12 @@ YUANYOUJIANG_1:
   item:
     name: '&2&l原油浆&c(I)'
     lore:
-    - '&7最新款可升级式机器'
-    - '&7无限生产原油!'
-    - '&b&l⇨ 速度：1x'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1000 J 可存储'
-    - '&8⇨ &e⚡&7 512 J/s'
+      - '&7最新款可升级式机器'
+      - '&7无限生产原油!'
+      - '&b&l⇨ 速度：1x'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1000 J 可存储'
+      - '&8⇨ &e⚡&7 512 J/s'
     material_type: skull_hash
     material: aef5acf134fa952f13fdf0b3899060cc18ebc0a971347e45a31ecf95a4b0b31c
   speed: 1
@@ -25150,11 +25150,11 @@ YUANYOUJIANG_2:
   item:
     name: '&2&l原油浆&c(II)'
     lore:
-    - '&7无限生产原油!'
-    - '&b&l⇨ 速度：5x'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 10000 J 可存储'
-    - '&8⇨ &e⚡&7 2048 J/s'
+      - '&7无限生产原油!'
+      - '&b&l⇨ 速度：5x'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 10000 J 可存储'
+      - '&8⇨ &e⚡&7 2048 J/s'
     material_type: skull_hash
     material: 9fef722da05ae8bd8132905a11b5b6dfbf8e7ae0af599c8266e160fb05e6159b
   speed: 1
@@ -25219,11 +25219,11 @@ YUANYOUJIANG_3:
   item:
     name: '&2&l原油浆&c(III)'
     lore:
-    - '&7无限生产原油!'
-    - '&b&l⇨ 速度：10x'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 20000 J 可存储'
-    - '&8⇨ &e⚡&7 14400 J/s'
+      - '&7无限生产原油!'
+      - '&b&l⇨ 速度：10x'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 20000 J 可存储'
+      - '&8⇨ &e⚡&7 14400 J/s'
     material_type: skull_hash
     material: f7e541dfb4ba1f7dc28b548e347abbdc987ebe0e61c49fa87111ef1b2dcb2218
   speed: 1
@@ -25288,10 +25288,10 @@ DIYUKONGJIAN:
   item:
     name: '&3&l地狱空间'
     lore:
-    - '&7&l 秘境世界!'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1000000 J 可存储'
-    - '&8⇨ &e⚡&7 400000 J/s'
+      - '&7&l 秘境世界!'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1000000 J 可存储'
+      - '&8⇨ &e⚡&7 400000 J/s'
     material_type: skull_hash
     material: 584d7d2d1cf8e05a28a6be12fdf3eac20bbf5c2364c400f6466566778f548eba
   speed: 1
@@ -25504,10 +25504,10 @@ MODIKONGJIAN:
   item:
     name: '&4&l末地空间'
     lore:
-    - '&7&l 秘境世界!'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1000000 J 可存储'
-    - '&8⇨ &e⚡&7 400000 J/s'
+      - '&7&l 秘境世界!'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1000000 J 可存储'
+      - '&8⇨ &e⚡&7 400000 J/s'
     material_type: skull_hash
     material: e48d7968c23d537bfeaed6de7cdbe7330afe405e00c5bd3eed8ab291fd59c5ed
   speed: 1
@@ -25648,10 +25648,10 @@ MIJINGHUAYUAN:
   item:
     name: '&5&l秘境花园'
     lore:
-    - '&7&l宇宙中的秘境!'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 6400 J 可存储'
-    - '&8⇨ &e⚡&7 3200 J/s'
+      - '&7&l宇宙中的秘境!'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 6400 J 可存储'
+      - '&8⇨ &e⚡&7 3200 J/s'
     material_type: skull_hash
     material: f2b41f1f0d8efc6fc9383a6b8146159e165a39a409ef0fedbc45842b656441e7
   speed: 1
@@ -25908,10 +25908,10 @@ JINSHUJGC:
   item:
     name: '&b&l金属加工厂'
     lore:
-    - '&7&l工业时代!'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 2000 J 可存储'
-    - '&8⇨ &e⚡&7 1500 J/s'
+      - '&7&l工业时代!'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 2000 J 可存储'
+      - '&8⇨ &e⚡&7 1500 J/s'
     material_type: skull_hash
     material: 31a52b2c808695d8649d2336d4f4603a5e68291848cf4885ff5e971557887f92
   speed: 1
@@ -26116,10 +26116,10 @@ SHOUMOJGC:
   item:
     name: '&b&l手磨加工厂'
     lore:
-    - '&7&l工业时代!'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 2000 J 可存储'
-    - '&8⇨ &e⚡&7 1000 J/s'
+      - '&7&l工业时代!'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 2000 J 可存储'
+      - '&8⇨ &e⚡&7 1000 J/s'
     material_type: skull_hash
     material: 368ab8cf594da55f90f593bdc0b41e05925d75daa3ee7f1b49c2421d2bdead0
   speed: 1
@@ -26292,10 +26292,10 @@ JIHANZHIDI:
   item:
     name: '&b&l极寒之地'
     lore:
-    - '&7&l冰天雪地!'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1024 J 可存储'
-    - '&8⇨ &e⚡&7 1024 J/s'
+      - '&7&l冰天雪地!'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1024 J 可存储'
+      - '&8⇨ &e⚡&7 1024 J/s'
     material_type: skull_hash
     material: ddba642efffa13ec3730eafc5914ab68115c1f998803f74452e2e0cd26af0b8
   speed: 1
@@ -26424,11 +26424,11 @@ DIAOYUJI:
   item:
     name: '&b&l虚空钓鱼机'
     lore:
-    - '&e&l从时间银河中钓取 &k&l !'
-    - '&7须将钓竿放入非消耗型物品槽内'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 2024 J 可存储'
-    - '&8⇨ &e⚡&7 2048 J/s'
+      - '&e&l从时间银河中钓取 &k&l !'
+      - '&7须将钓竿放入非消耗型物品槽内'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 2024 J 可存储'
+      - '&8⇨ &e⚡&7 2048 J/s'
     material_type: skull_hash
     material: ec4a74ac2d0ceff89157ad16121b6bcb2b5e5e694b460a27d3b9944f368c17ce
   speed: 1
@@ -26609,10 +26609,10 @@ WANNENGGONGCHANG:
   item:
     name: '&c&l万能工厂'
     lore:
-    - '&7生产各类方块'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 13200 J 可存储'
-    - '&8⇨ &e⚡&7 13600 J/s'
+      - '&7生产各类方块'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 13200 J 可存储'
+      - '&8⇨ &e⚡&7 13600 J/s'
     material_type: skull_hash
     material: f9dc48ba5326a4078d731cb00441e62ba9402400c0d175b9ac734d2d52cf2329
   speed: 1
@@ -26989,10 +26989,10 @@ SHITOUGONGCHANG:
   item:
     name: '&f&l石头工厂'
     lore:
-    - '&7将圆石烧制成大量石头!'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 10000 J 可存储'
-    - '&8⇨ &e⚡&7 3200 J/s'
+      - '&7将圆石烧制成大量石头!'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 10000 J 可存储'
+      - '&8⇨ &e⚡&7 3200 J/s'
     material_type: skull_hash
     material: 45b9037fc15d2c62693878a2a4a536f8c79af1d23ce678f34c1d54ce7e34a1f
   speed: 1
@@ -27061,13 +27061,13 @@ SHITOUGONGCHANG:
   item:
     name: '&64K金一体机 &7(&eI&7)'
     lore:
-    - '&e基础 机器'
-    - '&7速度 : 1x'
-    - ''
-    - '&f用于将金粉烧成4K金'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 200 J 可存储'
-    - '&8⇨ &e⚡&7 400 J/s'
+      - '&e基础 机器'
+      - '&7速度 : 1x'
+      - ''
+      - '&f用于将金粉烧成4K金'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 200 J 可存储'
+      - '&8⇨ &e⚡&7 400 J/s'
     material_type: skull_hash
     material: 9fef722da05ae8bd8132905a11b5b6dfbf8e7ae0af599c8266e160fb05e6159b
   speed: 1
@@ -27132,13 +27132,13 @@ SHITOUGONGCHANG:
   item:
     name: '&64K金一体机 &7(&eII&7)'
     lore:
-    - '&a中型 机器'
-    - '&7速度 : 2x'
-    - ''
-    - '&f用于将金粉烧成4K金'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 230 J 可存储'
-    - '&8⇨ &e⚡&7 460 J/s'
+      - '&a中型 机器'
+      - '&7速度 : 2x'
+      - ''
+      - '&f用于将金粉烧成4K金'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 230 J 可存储'
+      - '&8⇨ &e⚡&7 460 J/s'
     material_type: skull_hash
     material: dcd7a00de13ec9f3c59d7cf902d980f5d29002c0dad754acbda0f6c2b698fd05
   speed: 1
@@ -27203,13 +27203,13 @@ SHITOUGONGCHANG:
   item:
     name: '&64K金一体机 &7(&eIII&7)'
     lore:
-    - '&4终极 机器'
-    - '&7速度 : 10x'
-    - ''
-    - '&f用于将金粉烧成4K金'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 350 J 可存储'
-    - '&8⇨ &e⚡&7 700 J/s'
+      - '&4终极 机器'
+      - '&7速度 : 10x'
+      - ''
+      - '&f用于将金粉烧成4K金'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 350 J 可存储'
+      - '&8⇨ &e⚡&7 700 J/s'
     material_type: skull_hash
     material: dcd7a00de13ec9f3c59d7cf902d980f5d29002c0dad754acbda0f6c2b698fd05
   speed: 1
@@ -27278,10 +27278,10 @@ SAPLING_INTEGRATED_MACHINE:
   item:
     name: '&a&l树苗转化机'
     lore:
-    - '&f种树实现碳中和'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 60 J 可存储'
-    - '&8⇨ &e⚡&7 120 J/s'
+      - '&f种树实现碳中和'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 60 J 可存储'
+      - '&8⇨ &e⚡&7 120 J/s'
     material_type: skull_hash
     material: c2847cd5717e5f5a64e1ba9cb481dc9e22c78ca23f8516d553f55412fa113e0
   speed: 1
@@ -27454,10 +27454,10 @@ RAIL_INTEGRATED_MACHINE:
   item:
     name: '&f&l基础铁轨一体机'
     lore:
-    - '&7修建铁路必备'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 60 J 可存储'
-    - '&8⇨ &e⚡&7 120 J/s'
+      - '&7修建铁路必备'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 60 J 可存储'
+      - '&8⇨ &e⚡&7 120 J/s'
     material_type: skull_hash
     material: 6d5b0e3aa61162a3c6538985c5c11ceb96d5605b3ce9234c88f4fbd723475d
   speed: 1
@@ -27542,10 +27542,10 @@ CONCRETE_FORMING_MACHINE:
   item:
     name: '&6&l高级混凝土成型机'
     lore:
-    - '&7批量浇筑'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1000 J 可存储'
-    - '&8⇨ &e⚡&7 50 J/s'
+      - '&7批量浇筑'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1000 J 可存储'
+      - '&8⇨ &e⚡&7 50 J/s'
     material_type: skull_hash
     material: 918aa131cfb55a9268c8a5b40bb9772591d9c62b08f04cd141bb2ed6625156df
   speed: 1
@@ -27790,10 +27790,10 @@ HAIMAN_FOXY_PRODUCER:
   item:
     name: '&c&l生物献祭机'
     lore:
-    - '&7在虚无中献祭生物'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 12000 J 可存储'
-    - '&8⇨ &e⚡&7 2400 J/s'
+      - '&7在虚无中献祭生物'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 12000 J 可存储'
+      - '&8⇨ &e⚡&7 2400 J/s'
     material_type: skull_hash
     material: 72de8ed72148b79600f5cbbc6b2b6344d7c141c3a482ab7c82cdeae80371a06f
   speed: 1
@@ -27986,10 +27986,10 @@ HAIMAN_YASUOJI:
   item:
     name: '&f&l海曼压缩机'
     lore:
-    - '&7压缩一些杂七杂八的物品'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 12000 J 可存储'
-    - '&8⇨ &e⚡&7 4000 J/s'
+      - '&7压缩一些杂七杂八的物品'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 12000 J 可存储'
+      - '&8⇨ &e⚡&7 4000 J/s'
     material_type: skull_hash
     material: 65e84f93e79312a1e2c53442ac5a08a9653c461184801b0c8098a73ed07d6ce7
   speed: 1
@@ -28090,11 +28090,11 @@ HAIMAN_NAMI_CRAFTING_TABLE:
   item:
     name: '&5&l电动纳米工作台'
     lore:
-    - '&7一种小型机器'
-    - '&7仅能制作材料'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 12000 J 可存储'
-    - '&8⇨ &e⚡&7 800 J/s'
+      - '&7一种小型机器'
+      - '&7仅能制作材料'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 12000 J 可存储'
+      - '&8⇨ &e⚡&7 800 J/s'
     material_type: skull_hash
     material: bc40883f14d1d21e33fb7ee428936ecf088006c81b55996b1e153a8add1ab6a9
   speed: 1
@@ -28239,11 +28239,11 @@ ERDIAOZHUANGPEI:
   item:
     name: '&6&l饵料装配机'
     lore:
-    - '&7为钓鱼竿装配饵料'
-    - '&7但是优化了钓鱼竿'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 40 J 可存储'
-    - '&8⇨ &e⚡&7 40 J/s'
+      - '&7为钓鱼竿装配饵料'
+      - '&7但是优化了钓鱼竿'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 40 J 可存储'
+      - '&8⇨ &e⚡&7 40 J/s'
     material_type: skull_hash
     material: fbf5ae88f656aff4a91c64800951455e12222c310583ca28f93ce5148b73832b
   speed: 1
@@ -28320,10 +28320,10 @@ HAIMAN_LOW_RESISTANCE:
   item:
     name: '&b&l海曼牌小电阻'
     lore:
-    - '&7是否觉得你的电太多了？'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 25000 J 可存储'
-    - '&8⇨ &e⚡&7 50000 J/s'
+      - '&7是否觉得你的电太多了？'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 25000 J 可存储'
+      - '&8⇨ &e⚡&7 50000 J/s'
     material_type: skull_hash
     material: d83ed217dfd497539e86ab5b898b7b3bf5a186492e24f8b37a634a7947d1180
   speed: 1
@@ -28380,10 +28380,10 @@ HAIMAN_TIAODIAN_MAHCINE_G:
   item:
     name: '&e&l个位耗电式调电仪'
     lore:
-    - '&7校准电量'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1 J 可存储'
-    - '&8⇨ &e⚡&7 2 J/s'
+      - '&7校准电量'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1 J 可存储'
+      - '&8⇨ &e⚡&7 2 J/s'
     material_type: skull_hash
     material: a0cdb66b5179b2af60b7cf045cd403c9a304a4b18aa1a5eaa2d8c4782149294f
   speed: 1
@@ -28440,10 +28440,10 @@ HAIMAN_TIAODIAN_MAHCINE_S:
   item:
     name: '&e&l十位耗电式调电仪'
     lore:
-    - '&7校准电量'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 10 J 可存储'
-    - '&8⇨ &e⚡&7 20 J/s'
+      - '&7校准电量'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 10 J 可存储'
+      - '&8⇨ &e⚡&7 20 J/s'
     material_type: skull_hash
     material: a0cdb66b5179b2af60b7cf045cd403c9a304a4b18aa1a5eaa2d8c4782149294f
   speed: 1
@@ -28500,10 +28500,10 @@ HAIMAN_TIAODIAN_MAHCINE_B:
   item:
     name: '&e&l百位耗电式调电仪'
     lore:
-    - '&7校准电量'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 100 J 可存储'
-    - '&8⇨ &e⚡&7 200 J/s'
+      - '&7校准电量'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 100 J 可存储'
+      - '&8⇨ &e⚡&7 200 J/s'
     material_type: skull_hash
     material: a0cdb66b5179b2af60b7cf045cd403c9a304a4b18aa1a5eaa2d8c4782149294f
   speed: 1
@@ -28560,10 +28560,10 @@ HAIMAN_TIAODIAN_MAHCINE_Q:
   item:
     name: '&e&l千位耗电式调电仪'
     lore:
-    - '&7校准电量'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1000 J 可存储'
-    - '&8⇨ &e⚡&7 2000 J/s'
+      - '&7校准电量'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1000 J 可存储'
+      - '&8⇨ &e⚡&7 2000 J/s'
     material_type: skull_hash
     material: a0cdb66b5179b2af60b7cf045cd403c9a304a4b18aa1a5eaa2d8c4782149294f
   speed: 1
@@ -28620,10 +28620,10 @@ FENGCGZ_MACHINE:
   item:
     name: '&a&l蜂巢构造机'
     lore:
-    - '&7将蜂箱构造成蜂巢'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 4000 J 可存储'
-    - '&8⇨ &e⚡&7 1000 J/s'
+      - '&7将蜂箱构造成蜂巢'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 4000 J 可存储'
+      - '&8⇨ &e⚡&7 1000 J/s'
     material_type: skull_hash
     material: 20342dc9c2ad886acfe3ca2e987b7e28a87c774ca5f3d8cb2bfabe131cafe8
   speed: 1
@@ -28700,10 +28700,10 @@ JINFTZ_MACHINE:
   item:
     name: '&e&l金粉调制机'
     lore:
-    - '&7将金粉熔炼成原版金锭'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 8500 J 可存储'
-    - '&8⇨ &e⚡&7 170 J/s'
+      - '&7将金粉熔炼成原版金锭'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 8500 J 可存储'
+      - '&8⇨ &e⚡&7 170 J/s'
     material_type: skull_hash
     material: 226381f0db48004b4369e125b5e7569d951d2930cef0d75f8b033c1c00b5ed1e
   speed: 1
@@ -28780,10 +28780,10 @@ JGJ_MACHINE:
   item:
     name: '&4&l浆果机'
     lore:
-    - '&7创造浆果，享受浆果！'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 700 J 可存储'
-    - '&8⇨ &e⚡&7 140 J/s'
+      - '&7创造浆果，享受浆果！'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 700 J 可存储'
+      - '&8⇨ &e⚡&7 140 J/s'
     material_type: skull_hash
     material: 1819b0a63f7d0d20c2ce4c6651424de0a3b58ac0c647ced8bd218cacf93ea1aa
   speed: 1
@@ -28860,10 +28860,10 @@ SHUAGUAILONG_MACHINE:
   item:
     name: '&a&l刷怪笼构造机'
     lore:
-    - '&7构造刷怪笼'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 120000 J 可存储'
-    - '&8⇨ &e⚡&7 120000 J/s'
+      - '&7构造刷怪笼'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 120000 J 可存储'
+      - '&8⇨ &e⚡&7 120000 J/s'
     material_type: skull_hash
     material: 4faaf642babf93f96e146e2bb7b3cd70a4ec9d17f4a2957a99e2d8ed5bc8306d
   speed: 1
@@ -28952,10 +28952,10 @@ JINKUANGTIQU_MACHINE:
   item:
     name: '&e&l金矿提取机'
     lore:
-    - '&7从各种金矿/粗金中提取更多黄金'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 400 J 可存储'
-    - '&8⇨ &e⚡&7 80 J/s'
+      - '&7从各种金矿/粗金中提取更多黄金'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 400 J 可存储'
+      - '&8⇨ &e⚡&7 80 J/s'
     material_type: skull_hash
     material: e7a383cd2d8e3f9a2a9e9e2522dd18cfeed9cdaddf90c5e397973eef932b8bef
   speed: 1
@@ -29080,10 +29080,10 @@ GUZHITIQU_MACHINE:
   item:
     name: '&f&l骨质提取机'
     lore:
-    - '&7提取骨粉'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 500 J 可存储'
-    - '&8⇨ &e⚡&7 100 J/s'
+      - '&7提取骨粉'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 500 J 可存储'
+      - '&8⇨ &e⚡&7 100 J/s'
     material_type: skull_hash
     material: 7c7ffd6a6da16f491644cca321250fc2bee66a87fb7a8537d31dad1204a1b0
   speed: 1
@@ -29208,13 +29208,13 @@ LIZI_ZENGSHENG:
   item:
     name: '&a&l粒子增生机'
     lore:
-    - '&7可以在主世界自动生产粒子'
-    - '&7耗电量为粒子生产机的十倍'
-    - '&7你须要将粒子原胚放进输入槽中'
-    - '&7生产粒子不会消耗粒子原胚'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 5120 J 可存储'
-    - '&8⇨ &e⚡&7 5120 J/s'
+      - '&7可以在主世界自动生产粒子'
+      - '&7耗电量为粒子生产机的十倍'
+      - '&7你须要将粒子原胚放进输入槽中'
+      - '&7生产粒子不会消耗粒子原胚'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 5120 J 可存储'
+      - '&8⇨ &e⚡&7 5120 J/s'
     material_type: skull_hash
     material: de31efefdd9551af8a4349d3d21e5ec8f37e53c801eb25b14279d6a89fe0c01e
   speed: 1
@@ -29331,10 +29331,10 @@ WAMING_MACHINE:
   item:
     name: '&e&l蛙明机'
     lore:
-    - '&7呱~~呱~~'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 680 J 可存储'
-    - '&8⇨ &e⚡&7 136 J/s'
+      - '&7呱~~呱~~'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 680 J 可存储'
+      - '&8⇨ &e⚡&7 136 J/s'
     material_type: skull_hash
     material: 27dbd21251173df9e848b992c93064238238a2a1ea0f74d08b5c7e2242f790e5
   speed: 1
@@ -29423,10 +29423,10 @@ DANZH_MACHINE:
   item:
     name: '&c&l转蛋机'
     lore:
-    - '&7猜猜看这是什么蛋？'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 1600 J 可存储'
-    - '&8⇨ &e⚡&7 320 J/s'
+      - '&7猜猜看这是什么蛋？'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 1600 J 可存储'
+      - '&8⇨ &e⚡&7 320 J/s'
     material_type: skull_hash
     material: 58b30c1319eea75bae07613047bfedac17ff9b90bbf05c2801e7c2e47b0dfd1d
   speed: 1
@@ -29527,10 +29527,10 @@ SBYQH_MACHINE:
   item:
     name: '&f&l深板岩强化机'
     lore:
-    - '&7让深板岩更硬更强！'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 280000 J 可存储'
-    - '&8⇨ &e⚡&7 56000 J/s'
+      - '&7让深板岩更硬更强！'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 280000 J 可存储'
+      - '&8⇨ &e⚡&7 56000 J/s'
     material_type: skull_hash
     material: a49821c89947166e92bc073f8b02927c6ea99f2e749d87fc8de3b3aa9f7b524d
   speed: 1
@@ -29595,10 +29595,10 @@ YOUNI_MACHINE:
   item:
     name: '&8&l幽匿转换机'
     lore:
-    - '&7遁入黑暗吧！'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 2800 J 可存储'
-    - '&8⇨ &e⚡&7 560 J/s'
+      - '&7遁入黑暗吧！'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 2800 J 可存储'
+      - '&8⇨ &e⚡&7 560 J/s'
     material_type: skull_hash
     material: c8e22255d38c6da1196bf7c5e3f81d4abf56383cbec6aa5c8e4e919f92a0f3f3
   speed: 1
@@ -29723,10 +29723,10 @@ HUIXIANG_MACHINE:
   item:
     name: '&b&l回响构造机'
     lore:
-    - '&7回响式刻印'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 5000 J 可存储'
-    - '&8⇨ &e⚡&7 1000 J/s'
+      - '&7回响式刻印'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 5000 J 可存储'
+      - '&8⇨ &e⚡&7 1000 J/s'
     material_type: skull_hash
     material: 4322d1d2cbf82dd0b2012cda730c95cddd2e1229eaa621a5a49b174301aea723
   speed: 1
@@ -29815,10 +29815,10 @@ SHANYANGJIAO_MACHINE:
   item:
     name: '&6&l山羊角刻录机'
     lore:
-    - '&7可刻录多种号角声'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 5600 J 可存储'
-    - '&8⇨ &e⚡&7 1120 J/s'
+      - '&7可刻录多种号角声'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 5600 J 可存储'
+      - '&8⇨ &e⚡&7 1120 J/s'
     material_type: skull_hash
     material: 22d023d1c3fca0a0d64695e70b112cfa580072bbec072aaca0bcee5d131b70e3
   speed: 1
@@ -29967,10 +29967,10 @@ SGJ_MACHINE:
   item:
     name: '&c&l时光机'
     lore:
-    - '&7你说可以用它来穿越时空吗？'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 50000 J 可存储'
-    - '&8⇨ &e⚡&7 2000 J/s'
+      - '&7你说可以用它来穿越时空吗？'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 50000 J 可存储'
+      - '&8⇨ &e⚡&7 2000 J/s'
     material_type: skull_hash
     material: ad3bd0534027b540aea5ad3a315dd9c722a9d7abbc2769b68f77b2d38878815
   speed: 1
@@ -30071,10 +30071,10 @@ KYDJQ_MACHINE:
   item:
     name: '&b&l可疑的机器'
     lore:
-    - '&7这真的太可疑了'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 8000 J 可存储'
-    - '&8⇨ &e⚡&7 1600 J/s'
+      - '&7这真的太可疑了'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 8000 J 可存储'
+      - '&8⇨ &e⚡&7 1600 J/s'
     material_type: skull_hash
     material: 32427d026ee8e83f74422772bad0aae44a16eece708901fc206a51f4720f71ef
   speed: 1
@@ -30151,10 +30151,10 @@ MBYK_MACHINE:
   item:
     name: '&a&l模板刻印机'
     lore:
-    - '&7用来雕刻锻造模版'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 9000 J 可存储'
-    - '&8⇨ &e⚡&7 1800 J/s'
+      - '&7用来雕刻锻造模版'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 9000 J 可存储'
+      - '&8⇨ &e⚡&7 1800 J/s'
     material_type: skull_hash
     material: e1fd768cb0a95e56f30e61a44496efab37b469bfbc59f0992d7885756fda4ff2
   speed: 1
@@ -30411,10 +30411,10 @@ TPKY_MACHINE:
   item:
     name: '&6&l陶片刻印机'
     lore:
-    - '&7用来雕刻陶片'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 8600 J 可存储'
-    - '&8⇨ &e⚡&7 1720 J/s'
+      - '&7用来雕刻陶片'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 8600 J 可存储'
+      - '&8⇨ &e⚡&7 1720 J/s'
     material_type: skull_hash
     material: 5eb691cd1d78d9c9553446aa988e082db1d4524d27362349eb1c6a96c4afd954
   speed: 1
@@ -30707,10 +30707,10 @@ SWPY_1:
   item:
     name: '&d&l[ver:Classic]&6&lMC生物培育箱'
     lore:
-    - '&7可培育MC：Classic版本的生物'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 88000 J 可存储'
-    - '&8⇨ &e⚡&7 44000 J/s'
+      - '&7可培育MC：Classic版本的生物'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 88000 J 可存储'
+      - '&8⇨ &e⚡&7 44000 J/s'
     material_type: skull_hash
     material: 2dcbba6c751dab5f2b309bc5941e8ea79877cce4256936a189811ed7ec36d25c
   speed: 1
@@ -30835,10 +30835,10 @@ SWPY_2:
   item:
     name: '&d&l[ver:Indev-Alpha]&6&lMC生物培育箱'
     lore:
-    - '&7可培育MC：Indev-Alpha版本的生物'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 88000 J 可存储'
-    - '&8⇨ &e⚡&7 44000 J/s'
+      - '&7可培育MC：Indev-Alpha版本的生物'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 88000 J 可存储'
+      - '&8⇨ &e⚡&7 44000 J/s'
     material_type: skull_hash
     material: 2dcbba6c751dab5f2b309bc5941e8ea79877cce4256936a189811ed7ec36d25c
   speed: 1
@@ -31023,10 +31023,10 @@ SWPY_3:
   item:
     name: '&d&l[ver:BETA]&6&lMC生物培育箱'
     lore:
-    - '&7可培育MC：BETA版本的生物'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 88000 J 可存储'
-    - '&8⇨ &e⚡&7 44000 J/s'
+      - '&7可培育MC：BETA版本的生物'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 88000 J 可存储'
+      - '&8⇨ &e⚡&7 44000 J/s'
     material_type: skull_hash
     material: 2dcbba6c751dab5f2b309bc5941e8ea79877cce4256936a189811ed7ec36d25c
   speed: 1
@@ -31247,10 +31247,10 @@ SWPY_4:
   item:
     name: '&d&l[ver:1.0]&6&lMC生物培育箱'
     lore:
-    - '&7可培育MC：1.0版本的生物'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 88000 J 可存储'
-    - '&8⇨ &e⚡&7 44000 J/s'
+      - '&7可培育MC：1.0版本的生物'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 88000 J 可存储'
+      - '&8⇨ &e⚡&7 44000 J/s'
     material_type: skull_hash
     material: 2dcbba6c751dab5f2b309bc5941e8ea79877cce4256936a189811ed7ec36d25c
   speed: 1
@@ -31531,10 +31531,10 @@ SWPY_5:
   item:
     name: '&d&l[ver:1.1-1.3]&6&lMC生物培育箱'
     lore:
-    - '&7可培育MC：1.1-1.3版本的生物'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 88000 J 可存储'
-    - '&8⇨ &e⚡&7 44000 J/s'
+      - '&7可培育MC：1.1-1.3版本的生物'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 88000 J 可存储'
+      - '&8⇨ &e⚡&7 44000 J/s'
     material_type: skull_hash
     material: 2dcbba6c751dab5f2b309bc5941e8ea79877cce4256936a189811ed7ec36d25c
   speed: 1
@@ -31851,10 +31851,10 @@ SWPY_6:
   item:
     name: '&d&l[ver:1.4-1.5]&6&lMC生物培育箱'
     lore:
-    - '&7可培育MC：1.4-1.5版本的生物'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 88000 J 可存储'
-    - '&8⇨ &e⚡&7 44000 J/s'
+      - '&7可培育MC：1.4-1.5版本的生物'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 88000 J 可存储'
+      - '&8⇨ &e⚡&7 44000 J/s'
     material_type: skull_hash
     material: 2dcbba6c751dab5f2b309bc5941e8ea79877cce4256936a189811ed7ec36d25c
   speed: 1
@@ -32231,10 +32231,10 @@ SWPY_7:
   item:
     name: '&d&l[ver:1.6-1.7]&6&lMC生物培育箱'
     lore:
-    - '&7可培育MC：1.6-1.7版本的生物'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 88000 J 可存储'
-    - '&8⇨ &e⚡&7 44000 J/s'
+      - '&7可培育MC：1.6-1.7版本的生物'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 88000 J 可存储'
+      - '&8⇨ &e⚡&7 44000 J/s'
     material_type: skull_hash
     material: 2dcbba6c751dab5f2b309bc5941e8ea79877cce4256936a189811ed7ec36d25c
   speed: 1
@@ -32671,10 +32671,10 @@ SWPY_8:
   item:
     name: '&d&l[ver:1.8-1.9]&6&lMC生物培育箱'
     lore:
-    - '&7可培育MC：1.8-1.9版本的生物'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 88000 J 可存储'
-    - '&8⇨ &e⚡&7 44000 J/s'
+      - '&7可培育MC：1.8-1.9版本的生物'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 88000 J 可存储'
+      - '&8⇨ &e⚡&7 44000 J/s'
     material_type: skull_hash
     material: 2dcbba6c751dab5f2b309bc5941e8ea79877cce4256936a189811ed7ec36d25c
   speed: 1
@@ -33183,10 +33183,10 @@ SWPY_9:
   item:
     name: '&d&l[ver:1.10]&6&lMC生物培育箱'
     lore:
-    - '&7可培育MC：1.10版本的生物'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 88000 J 可存储'
-    - '&8⇨ &e⚡&7 44000 J/s'
+      - '&7可培育MC：1.10版本的生物'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 88000 J 可存储'
+      - '&8⇨ &e⚡&7 44000 J/s'
     material_type: skull_hash
     material: 2dcbba6c751dab5f2b309bc5941e8ea79877cce4256936a189811ed7ec36d25c
   speed: 1
@@ -33731,10 +33731,10 @@ SWPY_10:
   item:
     name: '&d&l[ver:1.11-1.12]&6&lMC生物培育箱'
     lore:
-    - '&7可培育MC：1.11-1.12版本的生物'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 88000 J 可存储'
-    - '&8⇨ &e⚡&7 44000 J/s'
+      - '&7可培育MC：1.11-1.12版本的生物'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 88000 J 可存储'
+      - '&8⇨ &e⚡&7 44000 J/s'
     material_type: skull_hash
     material: 2dcbba6c751dab5f2b309bc5941e8ea79877cce4256936a189811ed7ec36d25c
   speed: 1
@@ -34339,10 +34339,10 @@ SWPY_11:
   item:
     name: '&d&l[ver:1.13]&6&lMC生物培育箱'
     lore:
-    - '&7可培育MC：1.13版本的生物'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 88000 J 可存储'
-    - '&8⇨ &e⚡&7 44000 J/s'
+      - '&7可培育MC：1.13版本的生物'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 88000 J 可存储'
+      - '&8⇨ &e⚡&7 44000 J/s'
     material_type: skull_hash
     material: 2dcbba6c751dab5f2b309bc5941e8ea79877cce4256936a189811ed7ec36d25c
   speed: 1
@@ -35043,10 +35043,10 @@ SWPY_12:
   item:
     name: '&d&l[ver:1.14]&6&lMC生物培育箱'
     lore:
-    - '&7可培育MC：1.14版本的生物'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 88000 J 可存储'
-    - '&8⇨ &e⚡&7 44000 J/s'
+      - '&7可培育MC：1.14版本的生物'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 88000 J 可存储'
+      - '&8⇨ &e⚡&7 44000 J/s'
     material_type: skull_hash
     material: 2dcbba6c751dab5f2b309bc5941e8ea79877cce4256936a189811ed7ec36d25c
   speed: 1
@@ -35819,10 +35819,10 @@ SWPY_13:
   item:
     name: '&d&l[ver:1.15-1.16]&6&lMC生物培育箱'
     lore:
-    - '&7可培育MC：1.15-1.16版本的生物'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 88000 J 可存储'
-    - '&8⇨ &e⚡&7 44000 J/s'
+      - '&7可培育MC：1.15-1.16版本的生物'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 88000 J 可存储'
+      - '&8⇨ &e⚡&7 44000 J/s'
     material_type: skull_hash
     material: 2dcbba6c751dab5f2b309bc5941e8ea79877cce4256936a189811ed7ec36d25c
   speed: 1
@@ -36667,10 +36667,10 @@ SWPY_14:
   item:
     name: '&d&l[ver:1.17-1.18]&6&lMC生物培育箱'
     lore:
-    - '&7可培育MC：1.17-1.18版本的生物'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 88000 J 可存储'
-    - '&8⇨ &e⚡&7 44000 J/s'
+      - '&7可培育MC：1.17-1.18版本的生物'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 88000 J 可存储'
+      - '&8⇨ &e⚡&7 44000 J/s'
     material_type: skull_hash
     material: 2dcbba6c751dab5f2b309bc5941e8ea79877cce4256936a189811ed7ec36d25c
   speed: 1
@@ -37551,10 +37551,10 @@ SWPY_15:
   item:
     name: '&d&l[ver:1.19-1.20]&6&lMC生物培育箱'
     lore:
-    - '&7可培育MC：1.19-1.20版本的生物'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 88000 J 可存储'
-    - '&8⇨ &e⚡&7 44000 J/s'
+      - '&7可培育MC：1.19-1.20版本的生物'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 88000 J 可存储'
+      - '&8⇨ &e⚡&7 44000 J/s'
     material_type: skull_hash
     material: 2dcbba6c751dab5f2b309bc5941e8ea79877cce4256936a189811ed7ec36d25c
   speed: 1
@@ -38507,11 +38507,11 @@ SWPY_BOSS:
   item:
     name: '&d&l[ver:&4&lBOSS&d&l]&6&lMC生物培育箱'
     lore:
-    - '&7“我闻到了一股不详的气息”'
-    - '&7运行速度很慢，似乎需要借助外部手段加速'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 288000 J 可存储'
-    - '&8⇨ &e⚡&7 176000 J/s'
+      - '&7“我闻到了一股不详的气息”'
+      - '&7运行速度很慢，似乎需要借助外部手段加速'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 288000 J 可存储'
+      - '&8⇨ &e⚡&7 176000 J/s'
     material_type: skull_hash
     material: 6d0636fa7b7a812a1c7621e2399ed038d85b3eab03ca83c199b771af70e2b8c3
   speed: 1
@@ -38588,13 +38588,13 @@ HM_HQKYJ:
   item:
     name: '&4&l火漆刻印机'
     lore:
-    - '&7将原胚印刷成各式各样的粘液装备/工具'
-    - '&7使用时须要将火漆放入非消耗型物品槽内'
-    - '&7原胚指粘液装备/工具对应的原版物品材质'
-    - '&7例：吸血鬼之刀对应的原胚就是金剑'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 48000 J 可存储'
-    - '&8⇨ &e⚡&7 9600 J/s'
+      - '&7将原胚印刷成各式各样的粘液装备/工具'
+      - '&7使用时须要将火漆放入非消耗型物品槽内'
+      - '&7原胚指粘液装备/工具对应的原版物品材质'
+      - '&7例：吸血鬼之刀对应的原胚就是金剑'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 48000 J 可存储'
+      - '&8⇨ &e⚡&7 9600 J/s'
     material_type: skull_hash
     material: 81345cfaccf33bf667c9fbb4888082f5b2ec6f263a9f108e259ebec3f41ce986
   speed: 1
@@ -39783,10 +39783,10 @@ HAIMAN_CAIBAN:
   item:
     name: '&a&l菜板'
     lore:
-    - '&7切菜切啥都能切'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 100 J 可存储'
-    - '&8⇨ &e⚡&7 20 J/s'
+      - '&7切菜切啥都能切'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 100 J 可存储'
+      - '&8⇨ &e⚡&7 20 J/s'
     material_type: skull_hash
     material: eaa42c45fc468b250d964a628939d6951f5a57dacac423f2dfb951ba51ab6d29
   speed: 1
@@ -39909,7 +39909,7 @@ HAIMAN_CAIBAN:
           amount: 3
         2:
           material_type: mc
-          material: GRASS
+          material: SHORT_GRASS
           amount: 1
     '7':
       seconds: 1
@@ -39955,10 +39955,10 @@ VERSIONED_HAIMAN_CAIBAN:
   item:
     name: '&a&l菜板'
     lore:
-    - '&7切菜切啥都能切'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 100 J 可存储'
-    - '&8⇨ &e⚡&7 20 J/s'
+      - '&7切菜切啥都能切'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 100 J 可存储'
+      - '&8⇨ &e⚡&7 20 J/s'
     material_type: skull_hash
     material: eaa42c45fc468b250d964a628939d6951f5a57dacac423f2dfb951ba51ab6d29
   speed: 1
@@ -40122,7 +40122,7 @@ VERSIONED_HAIMAN_CAIBAN:
   id_alias: HAIMAN_CAIBAN
   register:
     conditions:
-    - version >= 1.20.3
+      - version >= 1.20.3
   input: [0, 1, 2, 9, 10, 11, 13, 18, 19, 20, 27, 28, 29, 30, 36, 37, 38, 39, 45, 46, 47, 48]
   output: [6, 7, 8, 15, 16, 17, 24, 25, 26, 32, 33, 34, 35, 41, 42, 43, 44, 50, 51, 52, 53]
 HAIMAN_DUJINTAI:
@@ -40131,10 +40131,10 @@ HAIMAN_DUJINTAI:
   item:
     name: '&e&l镀金台'
     lore:
-    - '&7给物品镶上黄金'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 2000 J 可存储'
-    - '&8⇨ &e⚡&7 400 J/s'
+      - '&7给物品镶上黄金'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 2000 J 可存储'
+      - '&8⇨ &e⚡&7 400 J/s'
     material_type: skull_hash
     material: 3dcf52b54524ecd5dfc6fadde637d60279bfcac3268b9bb93a9aca2f589a3f22
   speed: 1
@@ -40271,10 +40271,10 @@ HAIMAN_ZHIJIANTAI:
   item:
     name: '&e&l电动制箭台'
     lore:
-    - '&7用电力驱动制箭台'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 2000 J 可存储'
-    - '&8⇨ &e⚡&7 400 J/s'
+      - '&7用电力驱动制箭台'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 2000 J 可存储'
+      - '&8⇨ &e⚡&7 400 J/s'
     material_type: skull_hash
     material: 2760776074c23ae411ed46ef324a7a07282fbfbbbc5a99fcb3f5a8c9d6b02a53
   speed: 1
@@ -40363,10 +40363,10 @@ HAIMAN_FENGGANJI:
   item:
     name: '&e&l风干机'
     lore:
-    - '&7将物品风干'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 800 J 可存储'
-    - '&8⇨ &e⚡&7 160 J/s'
+      - '&7将物品风干'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 800 J 可存储'
+      - '&8⇨ &e⚡&7 160 J/s'
     material_type: skull_hash
     material: b99eb2998c2a78b6aa2eb592ef9c3648d3d2b01976d9f1dfc5dea37768d3d21c
   speed: 1
@@ -40587,10 +40587,10 @@ HAIMAN_BINGGANLLU:
   item:
     name: '&c&l饼干炉'
     lore:
-    - '&7烤COOKIE'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 850 J 可存储'
-    - '&8⇨ &e⚡&7 170 J/s'
+      - '&7烤COOKIE'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 850 J 可存储'
+      - '&8⇨ &e⚡&7 170 J/s'
     material_type: skull_hash
     material: 2f5cffcc555c21e17a68f411ad5c19f089d36f42c9e04cd5c5ee6cd77439970e
   speed: 1
@@ -40703,10 +40703,10 @@ HAIMAN_ZHUSHUICHI:
   item:
     name: '&b&l注水池'
     lore:
-    - '&7接水用的'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 150 J 可存储'
-    - '&8⇨ &e⚡&7 30 J/s'
+      - '&7接水用的'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 150 J 可存储'
+      - '&8⇨ &e⚡&7 30 J/s'
     material_type: skull_hash
     material: 1aaefc0dce2e3d940b959341fa20269553111241d1de87e9f29957b7776a16ec
   speed: 1
@@ -40783,10 +40783,10 @@ HAIMAN_WUJUNTAI:
   item:
     name: '&a&l无菌台'
     lore:
-    - '&7用来制药制肥料'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 550 J 可存储'
-    - '&8⇨ &e⚡&7 110 J/s'
+      - '&7用来制药制肥料'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 550 J 可存储'
+      - '&8⇨ &e⚡&7 110 J/s'
     material_type: skull_hash
     material: c2b7e6d2ecfe1d58e668238bba6e6ef3086019e7672b0cbee82c23a86f85fe7e
   speed: 1
@@ -40951,10 +40951,10 @@ HAIMAN_SHOUGONGTAI:
   item:
     name: '&6&l手工台'
     lore:
-    - '&7用来制作日常用品'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 420 J 可存储'
-    - '&8⇨ &e⚡&7 84 J/s'
+      - '&7用来制作日常用品'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 420 J 可存储'
+      - '&8⇨ &e⚡&7 84 J/s'
     material_type: skull_hash
     material: 247106a8274db6bcbcd8a466d97e90023101bb5a5c1519cda9ed2c20bed9f1d8
   speed: 1
@@ -41119,10 +41119,10 @@ HAIMAN_DIANRECHUANG:
   item:
     name: '&4&l电热床'
     lore:
-    - '&7睡在床上暖乎乎的'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 2000 J 可存储'
-    - '&8⇨ &e⚡&7 80 J/s'
+      - '&7睡在床上暖乎乎的'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 2000 J 可存储'
+      - '&8⇨ &e⚡&7 80 J/s'
     material: RED_BED
   speed: 1
   recipe_type: ENHANCED_CRAFTING_TABLE
@@ -41186,10 +41186,10 @@ HAIMAN_SHAGUO:
   item:
     name: '&f&l砂锅'
     lore:
-    - '&7熬汤专用锅'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 450 J 可存储'
-    - '&8⇨ &e⚡&7 90 J/s'
+      - '&7熬汤专用锅'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 450 J 可存储'
+      - '&8⇨ &e⚡&7 90 J/s'
     material_type: skull_hash
     material: f38064cd144de50df9b6d0d55998eda25e6bc97bd091af742a98511f2d3ab22
   speed: 1
@@ -41290,10 +41290,10 @@ HAIMAN_YINGLIAO_MACHINE:
   item:
     name: '&6&l饮料机'
     lore:
-    - '&7早上来杯牛奶'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 450 J 可存储'
-    - '&8⇨ &e⚡&7 100 J/s'
+      - '&7早上来杯牛奶'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 450 J 可存储'
+      - '&8⇨ &e⚡&7 100 J/s'
     material_type: skull_hash
     material: 24a37e0c123f4e1a7eb3cce17c12143f93c0c7ce8ce62d2ff86a7ce3a079f473
   speed: 1
@@ -41426,12 +41426,12 @@ HAIMAN_PAIZHUO:
   item:
     name: '&f&l牌桌'
     lore:
-    - '&7可以在输入槽和输出槽内打牌'
-    - '&7非消耗型物品槽内可以放计时器'
-    - '&7建议搭配货运实时清空输入槽和输出槽内的牌'
-    - '&b机器'
-    - '&8⇨ &e⚡&7 50 J 可存储'
-    - '&8⇨ &e⚡&7 10 J/s'
+      - '&7可以在输入槽和输出槽内打牌'
+      - '&7非消耗型物品槽内可以放计时器'
+      - '&7建议搭配货运实时清空输入槽和输出槽内的牌'
+      - '&b机器'
+      - '&8⇨ &e⚡&7 50 J 可存储'
+      - '&8⇨ &e⚡&7 10 J/s'
     material_type: skull_hash
     material: 145c70e5e5a96bae45c6530ca83faf53231642cca06dff5677640ede978ce3b2
   speed: 1

--- a/HaimanTech2-rsc/recipe_types.yml
+++ b/HaimanTech2-rsc/recipe_types.yml
@@ -1,1 +1,110 @@
-
+HAIMAN_INFO_FENZI_3:
+  lateInit: false
+  name: '&b&l分子重组仪 &7- &6III'
+  lore:
+    - '&7该物品在&b&l分子重组仪 &7- &6III&7里制作'
+  material_type: skull_hash
+  material: 5dff8dbbab15bfbb11e23b1f50b34ef548ad9832c0bd7f5a13791adad0057e1b
+HAIMAN_INFO_FENZI_4:
+  lateInit: false
+  name: '&b&l分子重组仪 &7- &cIV'
+  lore:
+    - '&7该物品在&b&l分子重组仪 &7- &cIV&7里制作'
+  material_type: skull_hash
+  material: 57ccd36dc8f72adcb1f8c8e61ee82cd96ead140cf2a16a1366be9b5a8e3cc3fc
+HAIMAN_INFO_FENZI_5:
+  lateInit: false
+  item_group: sakurafun_recipe
+  name: '&b&l分子重组仪 &7- &4V'
+  lore:
+    - '&7该物品在&b&l分子重组仪 &7- &4V&7里制作'
+  material_type: skull_hash
+  material: 30a35957fce2344aa8557ba6b36187ab415249934607bbbed2a053c3a86cafc0
+HAIMAN_INFO_FENZI_32767:
+  lateInit: false
+  item_group: sakurafun_recipe
+  name: '&b&l分子重组仪 &7- &5xxxMMDCCLXVII'
+  lore:
+    - '&7该物品在&b&l分子重组仪 &7- &5xxxMMDCCLXVII&7里制作'
+  material_type: skull_hash
+  material: 6f89b150be9c4c5249f355f68ea0c4391300a9be1f260d750fc35a1817ad796e
+HAIMAN_INFO_FENZI_GAIZHUANG:
+  lateInit: false
+  item_group: sakurafun_recipe
+  name: '&9&l分子重组仪改装机'
+  lore:
+    - '&7该物品需要在&9&l分子重组仪改装机&7中改装升级'
+  material_type: skull_hash
+  material: 2afeefa29bfdb3202238a2c4b8dcb750506a30d122600f88725e5aa247335460
+HAIMAN_INFO_FENZI_YEHUAJI:
+  lateInit: false
+  item_group: sakurafun_recipe
+  name: '&a&l燃料液化机'
+  lore:
+    - '&7该物品需要在&a&l燃料液化机&7中制作'
+  material_type: skull_hash
+  material: 6080972b7c32da650cc86e9aad665ed8d0d48a3bdb0ba234d4fceac024c7952e
+HAIMAN_INFO_COFFEE_MACHINE:
+  lateInit: false
+  item_group: sakurafun_recipe
+  name: '&c&l咖啡机'
+  lore:
+    - '&7该物品需要在&c&l咖啡机&7中制作'
+  material_type: skull_hash
+  material: 4552f7375672a5737f2ab766e5d1bcbfe8e12913cc9f044b43a2123a35185665
+HAIMAN_INFO_HAIMAN_ADVANCE_DYING:
+  lateInit: false
+  item_group: sakurafun_recipe
+  name: '&4&l终极染坊'
+  lore:
+    - '&7该物品需要在&4&l终极染坊&7中染色'
+  material_type: skull_hash
+  material: 391255206efac82b7e5ed6ce4b1ae5669ce55d087099299811007148bd1c8ece
+HAIMAN_INFO_CHUDIAN:
+  lateInit: false
+  item_group: sakurafun_recipe
+  name: '&d&l储电机'
+  lore:
+    - '&7该物品需要在&d&l储电机&7中充电'
+  material_type: skull_hash
+  material: 918a00b1c5ef0ba6d83e54fcbabb6272764f165d57ce8a26a916d4192a54c966
+HAIMAN_INFO_GUANGDIANJUHE:
+  lateInit: false
+  item_group: sakurafun_recipe
+  name: '&e&l电光聚合机'
+  lore:
+    - '&7该物品需要在&e&l电光聚合机&7中制作'
+  material_type: skull_hash
+  material: 366335847cba9aeaffc95cb109fdf55da13c95c97326a3bf5ddc7c99ee3
+HAIMAN_INFO_GUANGDIAN:
+  lateInit: false
+  item_group: sakurafun_recipe
+  name: '&e&l电光升级机'
+  lore:
+    - '&7该物品需要在&e&l电光升级机&7中制作'
+  material_type: skull_hash
+  material: 59d0f51f39e08e51cc83cbec01e3ce1362c70c02edc351902af8e7a5f6e201bc
+HAIMAN_INFO_BIRTHDAY_CAKE_STOVE:
+  lateInit: false
+  item_group: sakurafun_recipe
+  name: '&6&l烤箱'
+  lore:
+    - '&7该物品需要在&6&l烤箱&7中烘焙'
+  material_type: skull_hash
+  material: 8f9da46d97461a1be10600cc546a9d4613e16cfb5719eeb39042e501836008ca
+HAIMAN_INFO_WRITTEN_BOOK_CHANGER:
+  lateInit: false
+  item_group: sakurafun_recipe
+  name: '&6&l旧书机'
+  lore:
+    - '&7该物品需要在&6&l旧书机&7中制作'
+  material_type: skull_hash
+  material: 46ee7e906686abd5ec192b079314c45f1fb8171d9e13caa4cf9f63afc2263fd5
+HAIMAN_INFO_HEIDONG:
+  lateInit: false
+  item_group: sakurafun_recipe
+  name: '&8&l人造黑洞'
+  lore:
+    - '&7该物品需要在&8&l人造黑洞&7中制作'
+  material_type: skull_hash
+  material: 65333ccc4075cef0de045b090a72b4fd5417f91e9e908b623fbbe48766d2aff5

--- a/HaimanTech2-rsc/saveditems/ARTIFICIAL_MILKY_WAY.yml
+++ b/HaimanTech2-rsc/saveditems/ARTIFICIAL_MILKY_WAY.yml
@@ -1,0 +1,26 @@
+item:
+  ==: org.bukkit.inventory.ItemStack
+  v: 3953
+  type: PLAYER_HEAD
+  meta:
+    ==: ItemMeta
+    meta-type: SKULL
+    display-name: '{"text":"","extra":[{"text":"人造银河系","obfuscated":false,"italic":false,"underlined":false,"strikethrough":false,"color":"light_purple","bold":true}]}'
+    lore:
+    - '{"text":"","extra":[{"text":"当一个银河系的能量被集中于此...","obfuscated":false,"italic":false,"underlined":false,"strikethrough":false,"color":"gray","bold":false}]}'
+    - '{"text":"","extra":[{"text":"发电机","obfuscated":false,"italic":false,"underlined":false,"strikethrough":false,"color":"green","bold":false}]}'
+    - '{"text":"","extra":[{"text":"⇨ ","obfuscated":false,"italic":false,"underlined":false,"strikethrough":false,"color":"dark_gray","bold":false},{"text":"⚡","italic":false,"color":"yellow"},{"text":"
+      120000000 J 可存储","italic":false,"color":"gray"}]}'
+    - '{"text":"","extra":[{"text":"⇨ ","obfuscated":false,"italic":false,"underlined":false,"strikethrough":false,"color":"dark_gray","bold":false},{"text":"⚡","italic":false,"color":"yellow"},{"text":"
+      37500000 J/s","italic":false,"color":"gray"}]}'
+    PublicBukkitValues: |-
+      {
+          "slimefun:slimefun_item": "MAN_MADE_GALAXY"
+      }
+    skull-owner:
+      ==: PlayerProfile
+      uniqueId: c2ce1991-fa15-3da1-be71-04df5314ecd4
+      name: CS-CoreLib
+      properties:
+      - name: textures
+        value: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOWQzZDI1MGUyNWJiY2EzYTYyYmU1YjNlZjAyY2ZjYWI2ZGNkYzQyNDg4NGM5YTdkNWNjOTVjOWQwIn19fQ==


### PR DESCRIPTION
同时修改对应物品/机器的配方界面，删除了所有配方中的占位符（但保留了占位符本身）

大概是更整洁了？应该是一点影响都没有